### PR TITLE
Added `SimulationRunOptions` property to PIConfiguration and using it…

### DIFF
--- a/R/PIConfiguration.R
+++ b/R/PIConfiguration.R
@@ -49,7 +49,7 @@ PIConfiguration <- R6::R6Class(
       if (missing(value)) {
         private$.simulationRunOptions
       } else {
-        validateIsOfType(value, SimulationRunOptions, nullAllowed = TRUE)
+        validateIsOfType(value, "SimulationRunOptions", nullAllowed = TRUE)
         private$.simulationRunOptions <- value
       }
     }

--- a/R/PIConfiguration.R
+++ b/R/PIConfiguration.R
@@ -44,7 +44,7 @@ PIConfiguration <- R6::R6Class(
     },
 
     #' @field simulationRunOptions Object of type `SimulationRunOptions` that will be passed
-    #' to simulation runs. If `NULL`, default options are used
+    #' to simulation runs. If `NULL`, default options are used.
     simulationRunOptions = function(value) {
       if (missing(value)) {
         private$.simulationRunOptions

--- a/R/PIConfiguration.R
+++ b/R/PIConfiguration.R
@@ -41,12 +41,24 @@ PIConfiguration <- R6::R6Class(
         validateIsLogical(value)
         private$.printIterationFeedback <- value
       }
+    },
+
+    #' @field simulationRunOptions Object of type `SimulationRunOptions` that will be passed
+    #' to simulation runs. If `NULL`, default options are used
+    simulationRunOptions = function(value) {
+      if (missing(value)) {
+        private$.simulationRunOptions
+      } else {
+        validateIsOfType(value, SimulationRunOptions, nullAllowed = TRUE)
+        private$.simulationRunOptions <- value
+      }
     }
   ),
   private = list(
     .simulateSteadyState = NULL,
     .steadyStateTime = NULL,
-    .printIterationFeedback = NULL
+    .printIterationFeedback = NULL,
+    .simulationRunOptions = NULL
   ),
   public = list(
     #' @description

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -81,7 +81,8 @@ ParameterIdentification <- R6::R6Class(
         if (configuration$simulateSteadyState) {
           initialValues <- getSteadyState(
             quantitiesPaths = private$.stateVariables[[simulation$root$id]],
-            simulations = simulation, steadyStateTime = configuration$steadyStateTime
+            simulations = simulation, steadyStateTime = configuration$steadyStateTime,
+            simulationRunOptions = configuration$simulationRunOptions
           )[[simulation$id]]
 
           for (i in seq_along(initialValues$quantities)) {
@@ -90,7 +91,8 @@ ParameterIdentification <- R6::R6Class(
           }
         }
 
-        simulationResult <- ospsuite::runSimulation(simulation)
+        simulationResult <- ospsuite::runSimulation(simulation,
+                                                    simulationRunOptions = configuration$simulationRunOptions)
         return(simulationResult)
       }
 

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -81,7 +81,8 @@ ParameterIdentification <- R6::R6Class(
         if (configuration$simulateSteadyState) {
           initialValues <- getSteadyState(
             quantitiesPaths = private$.stateVariables[[simulation$root$id]],
-            simulations = simulation, steadyStateTime = configuration$steadyStateTime,
+            simulations = simulation, 
+            steadyStateTime = configuration$steadyStateTime,
             simulationRunOptions = configuration$simulationRunOptions
           )[[simulation$id]]
 

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -92,7 +92,8 @@ ParameterIdentification <- R6::R6Class(
         }
 
         simulationResult <- ospsuite::runSimulation(simulation,
-                                                    simulationRunOptions = configuration$simulationRunOptions)
+          simulationRunOptions = configuration$simulationRunOptions
+        )
         return(simulationResult)
       }
 

--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -22,6 +22,8 @@
 #' Any steady-state values below this value are considered as numerical noise
 #' and replaced by 0. If `lowerThreshold` is `NULL`, no cut-off is applied.
 #' Default value is 1e-15.
+#' @param simulationRunOptions Optional instance of a `SimulationRunOptions`
+#'  used during the simulation run.
 #'
 #' @return A named list, where the names are the IDs of the simulations and the
 #'   entries are lists containing `paths` and their `values` at the end of the
@@ -33,7 +35,8 @@ getSteadyState <- function(quantitiesPaths = NULL,
                            steadyStateTime,
                            ignoreIfFormula = TRUE,
                            stopIfNotFound = TRUE,
-                           lowerThreshold = 1e-15) {
+                           lowerThreshold = 1e-15,
+                           simulationRunOptions = NULL) {
   validateIsOfType(simulations, type = "Simulation")
   validateIsString(object = quantitiesPaths, nullAllowed = TRUE)
   simulations <- toList(simulations)
@@ -69,7 +72,8 @@ getSteadyState <- function(quantitiesPaths = NULL,
   }
 
   # Run simulations concurrently
-  simulationResults <- ospsuite::runSimulations(simulations = simulations)
+  simulationResults <- ospsuite::runSimulations(simulations = simulations,
+                                                simulationRunOptions = simulationRunOptions)
   # Container task is required for checking the "isFormula" property
   task <- ospsuite:::getContainerTask()
 

--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -72,8 +72,10 @@ getSteadyState <- function(quantitiesPaths = NULL,
   }
 
   # Run simulations concurrently
-  simulationResults <- ospsuite::runSimulations(simulations = simulations,
-                                                simulationRunOptions = simulationRunOptions)
+  simulationResults <- ospsuite::runSimulations(
+    simulations = simulations,
+    simulationRunOptions = simulationRunOptions
+  )
   # Container task is required for checking the "isFormula" property
   task <- ospsuite:::getContainerTask()
 

--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -38,7 +38,7 @@ getSteadyState <- function(quantitiesPaths = NULL,
                            lowerThreshold = 1e-15,
                            simulationRunOptions = NULL) {
   validateIsOfType(simulations, type = "Simulation")
-  validateIsString(object = quantitiesPaths, nullAllowed = TRUE)
+  validateIsString(quantitiesPaths, nullAllowed = TRUE)
   simulations <- toList(simulations)
 
   if (steadyStateTime <= 0) {

--- a/man/PIConfiguration.Rd
+++ b/man/PIConfiguration.Rd
@@ -21,6 +21,9 @@ should be brought to a steady-state first}
 \item{\code{printIterationFeedback}}{Boolean. If \code{TRUE}, the output of the
 residuals calculation will be printed after each iteration.
 Default is \code{FALSE}}
+
+\item{\code{simulationRunOptions}}{Object of type \code{SimulationRunOptions} that will be passed
+to simulation runs. If \code{NULL}, default options are used}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/getSteadyState.Rd
+++ b/man/getSteadyState.Rd
@@ -10,7 +10,8 @@ getSteadyState(
   steadyStateTime,
   ignoreIfFormula = TRUE,
   stopIfNotFound = TRUE,
-  lowerThreshold = 1e-15
+  lowerThreshold = 1e-15,
+  simulationRunOptions = NULL
 )
 }
 \arguments{
@@ -37,6 +38,9 @@ such errors. Check the outputs for empty values when using this option.}
 Any steady-state values below this value are considered as numerical noise
 and replaced by 0. If \code{lowerThreshold} is \code{NULL}, no cut-off is applied.
 Default value is 1e-15.}
+
+\item{simulationRunOptions}{Optional instance of a \code{SimulationRunOptions}
+used during the simulation run.}
 }
 \value{
 A named list, where the names are the IDs of the simulations and the


### PR DESCRIPTION
Fixes #13

This PR adds the option to provide a `SimulationRunOptions` object as part of the `PIConfiguration'. This way the user can define such properties like maximal number of cores, or whether the solver should ignore negaive values.