### PR TITLE
set ospsuite dependency to >=12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Encoding: UTF-8
 LazyData: true
 Depends:
     R (>= 4.1),
-    ospsuite (>= 11.0)
+    ospsuite (>= 12.0)
 Imports:
     ggplot2,
     ggtext,


### PR DESCRIPTION
OSPSuite-R v11.2.251 Installation Issue on R 4.3 (Issue #1248)

Installation fails due to encoding issues with "unicoße.pkml" during the remotes::install_github() process. Issue #1248 details this problem and its solution involving file renaming for compatibility.

Suggesting to use "Depends" ospsuite (>= 12.0)