### PR TITLE
Remove scaling option from PIConfiguration

### DIFF
--- a/R/PIConfiguration.R
+++ b/R/PIConfiguration.R
@@ -120,7 +120,6 @@ PIConfiguration <- R6::R6Class(
         residualWeightingMethod = "none",
         robustMethod = "none",
         scaleVar = FALSE,
-        scaling = "lin",
         linScaleCV = 0.2,
         logScaleSD = NULL
       )

--- a/R/enums.R
+++ b/R/enums.R
@@ -74,7 +74,6 @@ AlgorithmOptions_DEoptim <- ospsuite.utils::enum(DEoptim::DEoptim.control())
 #'   \item{\code{residualWeightingMethod}}{"none" by default; specifies method for residual weighting.}
 #'   \item{\code{robustMethod}}{"none" for standard analysis; selects method for robust outlier handling.}
 #'   \item{\code{scaleVar}}{FALSE by default; determines if scaling is applied to residuals.}
-#'   \item{\code{scaling}}{"lin" for linear scaling; affects data scaling approach.}
 #'   \item{\code{linScaleCV}}{0.2; coefficient of variation for linear scaling.}
 #'   \item{\code{logScaleSD}}{NULL; standard deviation for log scaling.}
 #' }
@@ -85,7 +84,6 @@ ObjectiveFunctionOptions <- ospsuite.utils::enum(list(
   residualWeightingMethod = "none",
   robustMethod = "none",
   scaleVar = FALSE,
-  scaling = "lin",
   linScaleCV = 0.2,
   logScaleSD = NULL
 ))
@@ -104,7 +102,6 @@ ObjectiveFunctionOptions <- ospsuite.utils::enum(list(
 #'   \item \code{residualWeightingMethod}: Methods for weighting residuals ("none", "std", "mean", "error").
 #'   \item \code{robustMethod}: Approaches for robust outlier handling ("none", "huber", "bisquare").
 #'   \item \code{scaleVar}: Boolean for variance scaling (TRUE, FALSE).
-#'   \item \code{scaling}: Data scaling methods ("lin" for linear, "log" for logarithmic).
 #'   \item \code{linScaleCV}: Coefficient of variation for linear scale, with numeric range 1e-9 to 1.
 #'   \item \code{logScaleSD}: Standard deviation for log scale, with numeric range 1e-9 to Inf.
 #' }
@@ -115,7 +112,6 @@ ObjectiveFunctionSpecs <- list(
   residualWeightingMethod = c("none", "std", "mean", "error"),
   robustMethod = c("none", "huber", "bisquare"),
   scaleVar = c(TRUE, FALSE),
-  scaling = c("lin", "log"),
   linScaleCV = list(type = "numeric", min = 1e-9, max = 1),
   logScaleSD = list(type = "numeric", min = 1e-9, max = Inf)
 )

--- a/man/ObjectiveFunctionOptions.Rd
+++ b/man/ObjectiveFunctionOptions.Rd
@@ -5,7 +5,7 @@
 \alias{ObjectiveFunctionOptions}
 \title{Objective Function Options for Model Fit Assessment}
 \format{
-An object of class \code{list} of length 7.
+An object of class \code{list} of length 6.
 }
 \usage{
 ObjectiveFunctionOptions
@@ -24,7 +24,6 @@ Settings include:
 \item{\code{residualWeightingMethod}}{"none" by default; specifies method for residual weighting.}
 \item{\code{robustMethod}}{"none" for standard analysis; selects method for robust outlier handling.}
 \item{\code{scaleVar}}{FALSE by default; determines if scaling is applied to residuals.}
-\item{\code{scaling}}{"lin" for linear scaling; affects data scaling approach.}
 \item{\code{linScaleCV}}{0.2; coefficient of variation for linear scaling.}
 \item{\code{logScaleSD}}{NULL; standard deviation for log scaling.}
 }

--- a/man/ObjectiveFunctionSpecs.Rd
+++ b/man/ObjectiveFunctionSpecs.Rd
@@ -5,7 +5,7 @@
 \alias{ObjectiveFunctionSpecs}
 \title{Objective Function Specifications}
 \format{
-An object of class \code{list} of length 7.
+An object of class \code{list} of length 6.
 }
 \usage{
 ObjectiveFunctionSpecs
@@ -22,7 +22,6 @@ Includes:
 \item \code{residualWeightingMethod}: Methods for weighting residuals ("none", "std", "mean", "error").
 \item \code{robustMethod}: Approaches for robust outlier handling ("none", "huber", "bisquare").
 \item \code{scaleVar}: Boolean for variance scaling (TRUE, FALSE).
-\item \code{scaling}: Data scaling methods ("lin" for linear, "log" for logarithmic).
 \item \code{linScaleCV}: Coefficient of variation for linear scale, with numeric range 1e-9 to 1.
 \item \code{logScaleSD}: Standard deviation for log scale, with numeric range 1e-9 to Inf.
 }

--- a/tests/testthat/test-pi-configuration.R
+++ b/tests/testthat/test-pi-configuration.R
@@ -57,7 +57,6 @@ test_that("objectiveFunctionOptions can be set and retrieved correctly", {
       residualWeightingMethod = "std",
       robustMethod = "huber",
       scaleVar = TRUE,
-      scaling = "log",
       linScaleCV = 0.5,
       logScaleSD = 0.5
     )
@@ -75,10 +74,6 @@ test_that("objectiveFunctionOptions can be set and retrieved correctly", {
     "huber"
   )
   expect_true(piConfiguration$objectiveFunctionOptions$scaleVar)
-  expect_equal(
-    piConfiguration$objectiveFunctionOptions$scaling,
-    "log"
-  )
   expect_equal(
     piConfiguration$objectiveFunctionOptions$linScaleCV,
     0.5


### PR DESCRIPTION
`scaling` should be only configured and validated in `PIOutputMapping` using `ScalingOptions`.
Removing `scaling` option from `PIConfiguration$objectiveFunctionOptions`

`scaling` Impact is already documented in `error-calculation` vignette