### PR TITLE
add .validateSimulationIds for Simulation ID checks

### DIFF
--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -548,6 +548,9 @@ ParameterIdentification <- R6::R6Class(
         private$.simulations[[idx]] <- simulation
         ids[[idx]] <- simulation$root$id
       }
+
+      .validateSimulationIds(ids, parameters, outputMappings)
+
       names(private$.simulations) <- ids
       private$.piParameters <- parameters
       private$.outputMappings <- c(outputMappings)

--- a/R/messages.R
+++ b/R/messages.R
@@ -31,3 +31,10 @@ messages$runningOptimizationAlgorithm <- function(name) {
 messages$hessianEstimation <- function() {
   "Post-hoc estimation of Hessian matrix."
 }
+
+messages$errorSimulationIdMissing <- function(id) {
+  paste0(
+    "Mismatch or missing ID detected: ", id,
+    ". Ensure each Simulation ID matches with corresponding PIParameter and OutputMapping IDs."
+  )
+}

--- a/R/utilities-simulation.R
+++ b/R/utilities-simulation.R
@@ -150,6 +150,41 @@ getSteadyState <- function(quantitiesPaths = NULL,
   return(.getSimulationContainer(entity$parentContainer))
 }
 
+#' Validates Matching IDs across Simulation IDs, PI Parameters, and Output Mappings
+#'
+#' Ensures that every Simulation ID is present and matches with corresponding IDs
+#' in PIParameter and OutputMapping instances. This function is crucial for
+#' maintaining consistency and preventing mismatches that could disrupt parameter
+#' identification processes.
+#'
+#' @param simulationIds Vector of simulation IDs.
+#' @param piParameters List of `PIParameter` instances, from which IDs are extracted
+#' and validated against simulationIds.
+#' @param outputMappings List of `OutputMapping` instances, from which IDs are
+#' extracted and validated against simulationIds.
+#'
+#' @return TRUE if all IDs match accordingly, otherwise throws an error detailing
+#' the mismatch or absence of IDs.
+#' @keywords internal
+.validateSimulationIds <- function(simulationIds, piParameters, outputMappings) {
+  # Extract unique IDs from piParameters
+  piParamIds <- lapply(piParameters, function(param) .getSimulationContainer(param$parameters[[1]])$id)
+  piParamIds <- unique(unlist(piParamIds))
+
+  # Extract unique IDs from outputMappings
+  outputMappingIds <- lapply(outputMappings, function(mapping) .getSimulationContainer(mapping$quantity)$id)
+  outputMappingIds <- unique(unlist(outputMappingIds))
+
+  # Validate that each simulationId is present in both piParamIds and outputMappingIds
+  for (id in simulationIds) {
+    if (!(id %in% piParamIds && id %in% outputMappingIds)) {
+      stop(messages$errorSimulationIdMissing(id))
+    }
+  }
+
+  return()
+}
+
 #' Stores current simulation output state
 #'
 #' @description Stores simulation output intervals, output time points,

--- a/tests/testthat/test-parameter-identification.R
+++ b/tests/testthat/test-parameter-identification.R
@@ -22,6 +22,20 @@ test_that("ParameterIdentification instance prints without error", {
   expect_no_error(print(piTask))
 })
 
+test_that("ParameterIdentification correctly throws an error upon missing Simulation IDs", {
+  simulationMismatch <- loadSimulation(
+    system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  )
+  expect_error(
+    ParameterIdentification$new(
+      simulations = simulationMismatch,
+      parameters = parameters,
+      outputMappings = outputMapping,
+    ),
+    "Mismatch or missing ID detected"
+  )
+})
+
 test_that("ParameterIdentification returns an infinite cost structure if the
           simulation is NA", {
   piTask <- createPiTask()


### PR DESCRIPTION
New .validateSimulationIds function for Simulation ID verification during ParameterIdentification initialization.

Validates Matching IDs across Simulation IDs, PI Parameters, and Output Mappings
Ensures that every Simulation ID is present and matches with corresponding IDs in PIParameter and OutputMapping instances. This function is crucial for maintaining consistency and preventing mismatches that could disrupt parameter
identification processes.