### PR TITLE
Optimize objectiveFunction by caching observed data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,7 @@
 - Optimization and CI estimation validated against PK-Sim results for the Aciclovir model, confirming correctness of estimates (#193).
 - Confidence interval estimation can be disabled by setting `piConfiguration$autoEstimateCI <- FALSE`; it can then be run explicitly with `ParameterIdentification$estimateCI()` (#196).
 - New vignette on confidence intervals, covering available methods, configuration, and result inspection (#198).
-
+- Improved performance of `.objectiveFunction()` by caching unit-converted observed data (#202).
 
 # ospsuite.parameteridentification 2.0.2
 

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -332,7 +332,7 @@ ParameterIdentification <- R6::R6Class(
         ))
       }
 
-      if (is.null(private$.obsCache)) {
+      if (is.null(private$.obsDataCache)) {
         private$.obsDataCache <- vector("list", length(outputMappings))
       }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1,0 +1,37 @@
+#' Convert units to a data type subset.
+#'
+#' Convert `data` so all rows use the single unit pair (`xUnit`, `yUnit`)
+#' found in rows where the `dataType` column equals the given `dataType`
+#' argument. If no unique pair exists, call the converter without explicit
+#' targets (no-op if already aligned).
+#'
+#' @param data A data frame (or a tibble) from `DataCombined$toDataFrame()`.
+#' @param dataType Character scalar, either `"simulated"` or `"observed"`.
+#'
+#' @return List with elements: `data` (converted data.frame) and `units`
+#' (list with `xUnit` and `yUnit` when a unique pair is found, otherwise `NULL`)
+#'
+#' @keywords internal
+#' @noRd
+.convertUnitsToSource <- function(data, dataType = c("simulated", "observed")) {
+  dataType <- match.arg(dataType)
+
+  subsetData <- data[data$dataType == dataType, , drop = FALSE]
+  uxAll <- unique(stats::na.omit(subsetData$xUnit))
+  uyAll <- unique(stats::na.omit(subsetData$yUnit))
+
+  if (length(uxAll) == 1L && length(uyAll) == 1L) {
+    xTarget <- uxAll[[1]]
+    yTarget <- uyAll[[1]]
+    list(
+      data  = ospsuite:::.unitConverter(data, xUnit = xTarget, yUnit = yTarget),
+      units = list(xUnit = xTarget, yUnit = yTarget)
+    )
+  } else {
+    # Fallback: generic conversion (no explicit targets)
+    list(
+      data  = ospsuite:::.unitConverter(data),
+      units = NULL
+    )
+  }
+}


### PR DESCRIPTION
Optimize objectiveFunction by caching observed data

Caches unit-converted observed rows and refreshes only simulated rows per evaluation. 
Eliminates redundant .unitConverter calls and improves performance in optimization/CI.

Closes #36 