### PR TITLE
Remove ineffective `clearMemory()` calls

### DIFF
--- a/R/Optimizer.R
+++ b/R/Optimizer.R
@@ -331,9 +331,6 @@ Optimizer <- R6::R6Class(
         costNew <- 0.5 * optimResult$value # fn(optimResult$par)
         paramHistory[[i]] <- c(p, i, newPar[p], costNew)
 
-        # Trigger .NET gc
-        ospsuite::clearMemory()
-
         # Stop when cost threshold is crossed
         if (costNew > costThreshold) {
           break
@@ -394,9 +391,6 @@ Optimizer <- R6::R6Class(
         )
 
         bootstrapResults[i, ] <- optimResult$par
-
-        # Trigger .NET gc
-        ospsuite::clearMemory()
       }
 
       bootstrapResults <- bootstrapResults[

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -869,7 +869,6 @@ ParameterIdentification <- R6::R6Class(
 
       private$.applyFinalValues(values = optimResult$par)
       private$.needBatchInitialization <- FALSE
-      ospsuite::clearMemory()
 
       if (!is.null(private$.pkMappings)) {
         piResult <- PKResult$new(
@@ -951,9 +950,6 @@ ParameterIdentification <- R6::R6Class(
         upper = upper,
         resetFn = function() private$.fnEvaluations <- 0
       )
-
-      # Trigger .NET gc
-      ospsuite::clearMemory()
 
       piResult <- PIResult$new(
         optimResult = private$.lastOptimResult,


### PR DESCRIPTION

Removes the four internal `ospsuite::clearMemory()` calls from `ParameterIdentification` (`run()`, `estimateCI()`) and `Optimizer` (profile-likelihood and bootstrap loops). Follow-up to #271.

`clearMemory()` forces an R `gc()` and a .NET `ForceGC` on every objective-function evaluation. Profiling shows no benefit: the .NET/CLR heap is flat-identical whether all sites fire or none do, and the only real growth is R-side (R heap, Ncells), which a GC can't reclaim. The calls cost a forced collection per evaluation while freeing nothing.


<img width="960" height="1200" alt="E23-memory" src="https://github.com/user-attachments/assets/df91e03f-1e68-4b26-9189-fa462531fcf8" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unnecessary memory management operations from optimization and confidence interval estimation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->