### PR TITLE
Require explicit bounds when a `PIParameters` start value is zero

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - `ParameterIdentification` now reads observed data once per optimization (and per bootstrap replicate) and caches it, instead of re-reading it from the underlying datasets on every objective function evaluation. This removes the dominant source of R heap growth during long optimizations and bootstrap runs (#271).
 - `plot.modelCost()` now reads the residual columns produced by the cost kernel, so it correctly plots raw residuals against time and overlays the weighted residuals (#275).
 - `ParameterIdentification` can now optimize state-variable parameters (those defined by a right-hand-side formula), which previously crashed (#280).
+- `PIParameters$new()` accepts optional `minValue`/`maxValue` and errors on a zero start value when no bounds are supplied (#282).
 
 # ospsuite.parameteridentification 2.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 - `ParameterIdentification` now reads observed data once per optimization (and per bootstrap replicate) and caches it, instead of re-reading it from the underlying datasets on every objective function evaluation. This removes the dominant source of R heap growth during long optimizations and bootstrap runs (#271).
 - `plot.modelCost()` now reads the residual columns produced by the cost kernel, so it correctly plots raw residuals against time and overlays the weighted residuals (#275).
 - `ParameterIdentification` can now optimize state-variable parameters (those defined by a right-hand-side formula), which previously crashed (#280).
-- `PIParameters$new()` accepts optional `minValue`/`maxValue` and errors on a zero start value when no bounds are supplied (#282).
+- `PIParameters$new()` accepts optional `minValue`/`maxValue`, errors on a zero start value when no bounds are supplied, and rejects zero-width bounds (`minValue == maxValue`) that leave nothing to optimize (#282).
 
 # ospsuite.parameteridentification 2.2.0
 

--- a/R/PIParameters.R
+++ b/R/PIParameters.R
@@ -51,16 +51,11 @@ PIParameters <- R6::R6Class(
         private$.minValue
       } else {
         ospsuite.utils::validateIsNumeric(value)
-        if (value > private$.startValue) {
-          stop(paste0(
-            "The minimal value cannot be greater than the start value!
-          Provided minimal value: ",
-            value,
-            ". Current start value: ",
-            private$.startValue
-          ))
+        if (
+          value > private$.startValue || value >= (private$.maxValue %||% Inf)
+        ) {
+          stop(messages$errorInvalidBound(value, private$.startValue))
         }
-
         private$.minValue <- value
       }
     },
@@ -71,16 +66,11 @@ PIParameters <- R6::R6Class(
         private$.maxValue
       } else {
         ospsuite.utils::validateIsNumeric(value)
-        if (value < private$.startValue) {
-          stop(paste0(
-            "The maximal value cannot be smaller than the start value!
-          Provided maximal value: ",
-            value,
-            ". Current start value: ",
-            private$.startValue
-          ))
+        if (
+          value < private$.startValue || value <= (private$.minValue %||% -Inf)
+        ) {
+          stop(messages$errorInvalidBound(value, private$.startValue))
         }
-
         private$.maxValue <- value
       }
     },

--- a/R/PIParameters.R
+++ b/R/PIParameters.R
@@ -112,10 +112,14 @@ PIParameters <- R6::R6Class(
     #'   `PIParameters$startValue`. All parameters are optimized using this
     #'   unified value.
     #' @param parameters List of `Parameter` class objects to be optimized.
-    #' @param minValue Optional lower bound. Defaults to `NULL`, auto-generated
-    #'   from the start value. Required when the start value is zero.
-    #' @param maxValue Optional upper bound. Defaults to `NULL`, auto-generated
-    #'   from the start value. Required when the start value is zero.
+    #' @param minValue Optional lower bound. Defaults to `NULL`, in which case it
+    #'   is derived from the start value as `start * 0.1` (or `start * 10` when
+    #'   the start value is negative, so the bound stays below the start value).
+    #'   Required when the start value is zero.
+    #' @param maxValue Optional upper bound. Defaults to `NULL`, in which case it
+    #'   is derived from the start value as `start * 10` (or `start * 0.1` when
+    #'   the start value is negative, so the bound stays above the start value).
+    #'   Required when the start value is zero.
     #' @return A new `PIParameters` object.
     initialize = function(parameters, minValue = NULL, maxValue = NULL) {
       parameters <- c(parameters)

--- a/R/PIParameters.R
+++ b/R/PIParameters.R
@@ -112,22 +112,31 @@ PIParameters <- R6::R6Class(
     #'   `PIParameters$startValue`. All parameters are optimized using this
     #'   unified value.
     #' @param parameters List of `Parameter` class objects to be optimized.
+    #' @param minValue Optional lower bound. Defaults to `NULL`, auto-generated
+    #'   from the start value. Required when the start value is zero.
+    #' @param maxValue Optional upper bound. Defaults to `NULL`, auto-generated
+    #'   from the start value. Required when the start value is zero.
     #' @return A new `PIParameters` object.
-    initialize = function(parameters) {
+    initialize = function(parameters, minValue = NULL, maxValue = NULL) {
       parameters <- c(parameters)
       ospsuite.utils::validateIsOfType(parameters, "Parameter")
       .validateIsSameDimension(parameters)
 
       private$.parameters <- parameters
       private$.startValue <- parameters[[1]]$value
-      if (private$.startValue > 0) {
-        private$.minValue <- private$.startValue * 0.1
-        private$.maxValue <- private$.startValue * 10
-      } else {
-        private$.minValue <- private$.startValue * 10
-        private$.maxValue <- private$.startValue * 0.1
-      }
       private$.unit <- parameters[[1]]$unit
+
+      if (is.null(minValue) || is.null(maxValue)) {
+        if (private$.startValue == 0) {
+          stop(messages$errorZeroStartValueBounds())
+        }
+        scale <- if (private$.startValue > 0) c(0.1, 10) else c(10, 0.1)
+        minValue <- minValue %||% (private$.startValue * scale[[1]])
+        maxValue <- maxValue %||% (private$.startValue * scale[[2]])
+      }
+
+      self$minValue <- minValue
+      self$maxValue <- maxValue
     },
 
     #' @description Updates parameter(s) value. Value is specified in units of

--- a/R/messages.R
+++ b/R/messages.R
@@ -302,6 +302,12 @@ messages$errorZeroStartValueBounds <- function() {
   )
 }
 
+messages$errorInvalidBound <- function(value, startValue) {
+  ospsuite.utils::cliFormat(
+    "{.arg minValue} and {.arg maxValue} must bracket the start value ({.val {startValue}}) with {.arg minValue} < {.arg maxValue}. Provided bound: {.val {value}}."
+  )
+}
+
 messages$errorPKMappingUnitConversion <- function(
   pkParameter,
   unit,

--- a/R/messages.R
+++ b/R/messages.R
@@ -296,6 +296,12 @@ messages$errorNonPositiveValue <- function(argName) {
   )
 }
 
+messages$errorZeroStartValueBounds <- function() {
+  ospsuite.utils::cliFormat(
+    "Cannot derive optimization bounds from a start value of {.val {0}}. Provide explicit {.arg minValue} and {.arg maxValue} when creating the {.cls PIParameters}."
+  )
+}
+
 messages$errorPKMappingUnitConversion <- function(
   pkParameter,
   unit,

--- a/man/PIParameters.Rd
+++ b/man/PIParameters.Rd
@@ -55,10 +55,14 @@ unified value.
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{parameters}}{List of \code{Parameter} class objects to be optimized.}
-      \item{\code{minValue}}{Optional lower bound. Defaults to \code{NULL}, auto-generated
-from the start value. Required when the start value is zero.}
-      \item{\code{maxValue}}{Optional upper bound. Defaults to \code{NULL}, auto-generated
-from the start value. Required when the start value is zero.}
+      \item{\code{minValue}}{Optional lower bound. Defaults to \code{NULL}, in which case it
+is derived from the start value as \code{start * 0.1} (or \code{start * 10} when
+the start value is negative, so the bound stays below the start value).
+Required when the start value is zero.}
+      \item{\code{maxValue}}{Optional upper bound. Defaults to \code{NULL}, in which case it
+is derived from the start value as \code{start * 10} (or \code{start * 0.1} when
+the start value is negative, so the bound stays above the start value).
+Required when the start value is zero.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/PIParameters.Rd
+++ b/man/PIParameters.Rd
@@ -48,13 +48,17 @@ value is derived from the first parameter upon creation, modifiable via
 unified value.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{PIParameters$new(parameters)}
+    \preformatted{PIParameters$new(parameters, minValue = NULL, maxValue = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{parameters}}{List of \code{Parameter} class objects to be optimized.}
+      \item{\code{minValue}}{Optional lower bound. Defaults to \code{NULL}, auto-generated
+from the start value. Required when the start value is zero.}
+      \item{\code{maxValue}}{Optional upper bound. Defaults to \code{NULL}, auto-generated
+from the start value. Required when the start value is zero.}
     }
     \if{html}{\out{</div>}}
   }

--- a/tests/testthat/_snaps/pi-parameters.md
+++ b/tests/testthat/_snaps/pi-parameters.md
@@ -31,3 +31,11 @@
           startValue     minValue     maxValue
       1 1.764167e-05 1.764167e-06 0.0001764167
 
+# Zero start value without explicit bounds errors
+
+    Code
+      PIParameters$new(zeroParam)
+    Condition
+      Error in `initialize()`:
+      ! Cannot derive optimization bounds from a start value of 0. Provide explicit `minValue` and `maxValue` when creating the <PIParameters>.
+

--- a/tests/testthat/_snaps/pi-parameters.md
+++ b/tests/testthat/_snaps/pi-parameters.md
@@ -21,6 +21,22 @@
           startValue     minValue     maxValue
       1 1.764167e-05 1.764167e-06 0.0001764167
 
+# Start, min, and max values are set correctly (single parameter)
+
+    Code
+      piParam$minValue <- (newStartValue * 2)
+    Condition
+      Error:
+      ! `minValue` and `maxValue` must bracket the start value (3.52833353250001e-05) with `minValue` < `maxValue`. Provided bound: 7.05666706500003e-05.
+
+---
+
+    Code
+      piParam$maxValue <- (newStartValue / 2)
+    Condition
+      Error:
+      ! `minValue` and `maxValue` must bracket the start value (3.52833353250001e-05) with `minValue` < `maxValue`. Provided bound: 1.76416676625001e-05.
+
 # PIParameters with multiple parameters can export to data.frame
 
     Code
@@ -31,6 +47,22 @@
           startValue     minValue     maxValue
       1 1.764167e-05 1.764167e-06 0.0001764167
 
+# Start, min, and max values are set correctly (multiple parameters)
+
+    Code
+      piParam$minValue <- (newStartValue * 2)
+    Condition
+      Error:
+      ! `minValue` and `maxValue` must bracket the start value (4.33497537841081) with `minValue` < `maxValue`. Provided bound: 8.66995075682162.
+
+---
+
+    Code
+      piParam$maxValue <- (newStartValue / 2)
+    Condition
+      Error:
+      ! `minValue` and `maxValue` must bracket the start value (4.33497537841081) with `minValue` < `maxValue`. Provided bound: 2.16748768920541.
+
 # Zero start value without explicit bounds errors
 
     Code
@@ -38,4 +70,28 @@
     Condition
       Error in `initialize()`:
       ! Cannot derive optimization bounds from a start value of 0. Provide explicit `minValue` and `maxValue` when creating the <PIParameters>.
+
+# Zero-width bounds are rejected at a zero start value
+
+    Code
+      PIParameters$new(zeroParam, minValue = 0, maxValue = 0)
+    Condition
+      Error:
+      ! `minValue` and `maxValue` must bracket the start value (0) with `minValue` < `maxValue`. Provided bound: 0.
+
+# Zero-width bounds are rejected at a non-zero start value
+
+    Code
+      PIParameters$new(param, minValue = 5, maxValue = 5)
+    Condition
+      Error:
+      ! `minValue` and `maxValue` must bracket the start value (5) with `minValue` < `maxValue`. Provided bound: 5.
+
+# Setters cannot collapse the range to zero width
+
+    Code
+      piParam$maxValue <- 5
+    Condition
+      Error:
+      ! `minValue` and `maxValue` must bracket the start value (5) with `minValue` < `maxValue`. Provided bound: 5.
 

--- a/tests/testthat/test-pi-parameters.R
+++ b/tests/testthat/test-pi-parameters.R
@@ -151,3 +151,45 @@ test_that("Unit can be changed correctly", {
     fixed = TRUE
   )
 })
+
+test_that("Zero start value without explicit bounds errors", {
+  zeroParam <- ospsuite::getParameter(
+    "Aciclovir|Permeability",
+    testSimulation()
+  )
+  origValue <- zeroParam$value
+  zeroParam$setValue(0)
+  on.exit(zeroParam$setValue(origValue))
+
+  expect_snapshot(PIParameters$new(zeroParam), error = TRUE)
+})
+
+test_that("Zero start value with explicit bounds is accepted", {
+  zeroParam <- ospsuite::getParameter(
+    "Aciclovir|Permeability",
+    testSimulation()
+  )
+  origValue <- zeroParam$value
+  zeroParam$setValue(0)
+  on.exit(zeroParam$setValue(origValue))
+
+  piParam <- PIParameters$new(zeroParam, minValue = -1, maxValue = 1)
+  expect_equal(piParam$startValue, 0)
+  expect_equal(piParam$minValue, -1)
+  expect_equal(piParam$maxValue, 1)
+})
+
+test_that("Negative start value auto-generates ordered bounds", {
+  negParam <- ospsuite::getParameter(
+    "Aciclovir|Permeability",
+    testSimulation()
+  )
+  origValue <- negParam$value
+  negParam$setValue(-2)
+  on.exit(negParam$setValue(origValue))
+
+  piParam <- PIParameters$new(negParam)
+  expect_equal(piParam$startValue, -2)
+  expect_equal(piParam$minValue, -20)
+  expect_equal(piParam$maxValue, -0.2)
+})

--- a/tests/testthat/test-pi-parameters.R
+++ b/tests/testthat/test-pi-parameters.R
@@ -24,19 +24,13 @@ test_that("PIParameters can export to data.frame", {
   expect_snapshot(piParam$toDataFrame())
 })
 
-test_that("Start, min, and max values are set correctly", {
+test_that("Start, min, and max values are set correctly (single parameter)", {
   piParam <- PIParameters$new(testParam)
   newStartValue <- refVal * 2
   piParam$startValue <- newStartValue
   expect_equal(piParam$startValue, newStartValue)
-  expect_error(
-    piParam$minValue <- (newStartValue * 2),
-    "minimal value cannot be greater"
-  )
-  expect_error(
-    piParam$maxValue <- (newStartValue / 2),
-    "maximal value cannot be smaller"
-  )
+  expect_snapshot(piParam$minValue <- (newStartValue * 2), error = TRUE)
+  expect_snapshot(piParam$maxValue <- (newStartValue / 2), error = TRUE)
   piParam$minValue <- (newStartValue / 2)
   piParam$maxValue <- (newStartValue * 2)
   expect_equal(piParam$minValue, newStartValue / 2)
@@ -101,19 +95,13 @@ test_that("PIParameters with multiple parameters can export to data.frame", {
   expect_snapshot(piParam$toDataFrame())
 })
 
-test_that("Start, min, and max values are set correctly", {
+test_that("Start, min, and max values are set correctly (multiple parameters)", {
   piParam <- PIParameters$new(testParamsList)
   newStartValue <- refVal * 2
   piParam$startValue <- newStartValue
   expect_equal(piParam$startValue, newStartValue)
-  expect_error(
-    piParam$minValue <- (newStartValue * 2),
-    "minimal value cannot be greater"
-  )
-  expect_error(
-    piParam$maxValue <- (newStartValue / 2),
-    "maximal value cannot be smaller"
-  )
+  expect_snapshot(piParam$minValue <- (newStartValue * 2), error = TRUE)
+  expect_snapshot(piParam$maxValue <- (newStartValue / 2), error = TRUE)
   piParam$minValue <- (newStartValue / 2)
   piParam$maxValue <- (newStartValue * 2)
   expect_equal(piParam$minValue, newStartValue / 2)
@@ -192,4 +180,53 @@ test_that("Negative start value auto-generates ordered bounds", {
   expect_equal(piParam$startValue, -2)
   expect_equal(piParam$minValue, -20)
   expect_equal(piParam$maxValue, -0.2)
+})
+
+test_that("Zero-width bounds are rejected at a zero start value", {
+  zeroParam <- ospsuite::getParameter(
+    "Aciclovir|Permeability",
+    testSimulation()
+  )
+  origValue <- zeroParam$value
+  zeroParam$setValue(0)
+  on.exit(zeroParam$setValue(origValue))
+
+  expect_snapshot(
+    PIParameters$new(zeroParam, minValue = 0, maxValue = 0),
+    error = TRUE
+  )
+})
+
+test_that("Zero-width bounds are rejected at a non-zero start value", {
+  param <- ospsuite::getParameter("Aciclovir|Permeability", testSimulation())
+  origValue <- param$value
+  param$setValue(5)
+  on.exit(param$setValue(origValue))
+
+  expect_snapshot(
+    PIParameters$new(param, minValue = 5, maxValue = 5),
+    error = TRUE
+  )
+})
+
+test_that("A narrow but positive-width range is accepted", {
+  param <- ospsuite::getParameter("Aciclovir|Permeability", testSimulation())
+  origValue <- param$value
+  param$setValue(5)
+  on.exit(param$setValue(origValue))
+
+  piParam <- PIParameters$new(param, minValue = 5 - 1e-4, maxValue = 5 + 1e-4)
+  expect_equal(piParam$minValue, 5 - 1e-4)
+  expect_equal(piParam$maxValue, 5 + 1e-4)
+})
+
+test_that("Setters cannot collapse the range to zero width", {
+  param <- ospsuite::getParameter("Aciclovir|Permeability", testSimulation())
+  origValue <- param$value
+  param$setValue(5)
+  on.exit(param$setValue(origValue))
+
+  piParam <- PIParameters$new(param)
+  piParam$minValue <- 5
+  expect_snapshot(piParam$maxValue <- 5, error = TRUE)
 })


### PR DESCRIPTION
- `PIParameters$new()` gains optional `minValue` and `maxValue` arguments, validated through the existing bound setters

Closes #281


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `PIParameters` now supports optional `minValue` and `maxValue` constructor arguments.
  * When bounds are omitted, they’re derived from the start value (with sign-dependent scaling).
* **Bug Fixes**
  * Creating `PIParameters` errors when the start value is zero and explicit bounds aren’t provided.
  * Zero-width bounds (`minValue == maxValue`) are rejected, and provided bounds must properly bracket the start value.
* **Documentation**
  * Updated constructor usage and argument descriptions for `minValue`/`maxValue`.
* **Tests**
  * Expanded snapshot coverage for zero, negative, and zero-width bounds scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->