### PR TITLE
Apply parameter values in the unit declared by PIParameters$unit

### DIFF
--- a/.github/workflows/Main-Workflow.yaml
+++ b/.github/workflows/Main-Workflow.yaml
@@ -20,11 +20,18 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [bump-dev-version]
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
+    with:
+      # OSP r-universe provides prebuilt binaries for ospsuite.utils / ospsuite /
+      # tlf. Passing it lets pak resolve those without needing an entry per
+      # dependency in this package's own DESCRIPTION `Remotes:` field.
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
 
   test-coverage:
     if: ${{ !cancelled() }}
     needs: [bump-dev-version]
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/test-coverage.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -33,3 +40,5 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [bump-dev-version]
     uses:  Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ospsuite.parameteridentification (development version)
 
+## Major changes
+
+- `ParameterIdentification` now converts parameter values from `PIParameters$unit` to the base unit before applying them to the model. Previously they were applied unconverted, so a non-base unit silently optimized the wrong quantity (#300).
+
 ## Minor improvements and bug fixes
 
 - `ParameterIdentification` now reads observed data once per optimization (and per bootstrap replicate) and caches it, instead of re-reading it from the underlying datasets on every objective function evaluation. This removes the dominant source of R heap growth during long optimizations and bootstrap runs (#271).

--- a/R/PIParameters.R
+++ b/R/PIParameters.R
@@ -79,9 +79,7 @@ PIParameters <- R6::R6Class(
     #'   automatically adjust min/max/start values. Values are converted from
     #'   this unit to the parameter's base unit before they are applied to the
     #'   model. With the `HJKB` algorithm, the declared unit also affects the
-    #'   search resolution because `HJKB` probes with absolute step sizes. See
-    #'   `vignette("user-guide", package = "ospsuite.parameteridentification")`
-    #'   for detail.
+    #'   search resolution because `HJKB` probes with absolute step sizes.
     unit = function(value) {
       if (missing(value)) {
         private$.unit

--- a/R/PIParameters.R
+++ b/R/PIParameters.R
@@ -78,7 +78,10 @@ PIParameters <- R6::R6Class(
     #' @field unit Parameter value units. Changing the unit does NOT
     #'   automatically adjust min/max/start values. Values are converted from
     #'   this unit to the parameter's base unit before they are applied to the
-    #'   model.
+    #'   model. With the `HJKB` algorithm, the declared unit also affects the
+    #'   search resolution because `HJKB` probes with absolute step sizes. See
+    #'   `vignette("user-guide", package = "ospsuite.parameteridentification")`
+    #'   for detail.
     unit = function(value) {
       if (missing(value)) {
         private$.unit

--- a/R/PIParameters.R
+++ b/R/PIParameters.R
@@ -76,7 +76,9 @@ PIParameters <- R6::R6Class(
     },
 
     #' @field unit Parameter value units. Changing the unit does NOT
-    #'   automatically adjust min/max/start values.
+    #'   automatically adjust min/max/start values. Values are converted from
+    #'   this unit to the parameter's base unit before they are applied to the
+    #'   model.
     unit = function(value) {
       if (missing(value)) {
         private$.unit

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -214,9 +214,10 @@ ParameterIdentification <- R6::R6Class(
 
         # Seed each optimization parameter's start value into its variable bucket.
         for (piParameter in private$.piParameters) {
+          baseValue <- .toBaseValue(piParameter, piParameter$startValue)
           for (parameter in piParameter$parameters) {
             simId <- .getSimulationContainer(parameter)$id
-            private$.setVariableValue(simId, parameter, piParameter$startValue)
+            private$.setVariableValue(simId, parameter, baseValue)
           }
         }
 
@@ -477,9 +478,10 @@ ParameterIdentification <- R6::R6Class(
     .getPKValues = function(paramValues) {
       for (idx in seq_along(paramValues)) {
         piParameter <- private$.piParameters[[idx]]
+        baseValue <- .toBaseValue(piParameter, paramValues[[idx]])
         for (parameter in piParameter$parameters) {
           simId <- .getSimulationContainer(parameter)$id
-          private$.setVariableValue(simId, parameter, paramValues[[idx]])
+          private$.setVariableValue(simId, parameter, baseValue)
         }
       }
 
@@ -563,9 +565,10 @@ ParameterIdentification <- R6::R6Class(
       # parameters list.
       for (idx in seq_along(currVals)) {
         piParameter <- private$.piParameters[[idx]]
+        baseValue <- .toBaseValue(piParameter, currVals[[idx]])
         for (parameter in piParameter$parameters) {
           simId <- .getSimulationContainer(parameter)$id
-          private$.setVariableValue(simId, parameter, currVals[[idx]])
+          private$.setVariableValue(simId, parameter, baseValue)
         }
       }
 

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -123,6 +123,21 @@ ParameterIdentification <- R6::R6Class(
       }
     },
 
+    # Applies a vector of optimizer values, one entry per `PIParameters` group,
+    # to every underlying model parameter. Values arrive in each group's
+    # `$unit`; `addRunValues()` reads base units, so they are converted here.
+    # This is the only place that writes into the variable buckets.
+    .applyParameterValues = function(values) {
+      for (idx in seq_along(values)) {
+        piParameter <- private$.piParameters[[idx]]
+        baseValue <- .toBaseValue(piParameter, values[[idx]])
+        for (parameter in piParameter$parameters) {
+          simId <- .getSimulationContainer(parameter)$id
+          private$.setVariableValue(simId, parameter, baseValue)
+        }
+      }
+    },
+
     # Batch Initialization for Simulations
     #
     # Initializes simulation batches, preparing them for parameter
@@ -213,13 +228,9 @@ ParameterIdentification <- R6::R6Class(
         }
 
         # Seed each optimization parameter's start value into its variable bucket.
-        for (piParameter in private$.piParameters) {
-          baseValue <- .toBaseValue(piParameter, piParameter$startValue)
-          for (parameter in piParameter$parameters) {
-            simId <- .getSimulationContainer(parameter)$id
-            private$.setVariableValue(simId, parameter, baseValue)
-          }
-        }
+        private$.applyParameterValues(
+          vapply(private$.piParameters, function(p) p$startValue, numeric(1))
+        )
 
         # Create simulation batches for identification runs
         for (simulation in private$.simulations) {
@@ -476,14 +487,7 @@ ParameterIdentification <- R6::R6Class(
     },
 
     .getPKValues = function(paramValues) {
-      for (idx in seq_along(paramValues)) {
-        piParameter <- private$.piParameters[[idx]]
-        baseValue <- .toBaseValue(piParameter, paramValues[[idx]])
-        for (parameter in piParameter$parameters) {
-          simId <- .getSimulationContainer(parameter)$id
-          private$.setVariableValue(simId, parameter, baseValue)
-        }
-      }
+      private$.applyParameterValues(paramValues)
 
       for (simId in names(private$.simulationBatches)) {
         simBatch <- private$.simulationBatches[[simId]]
@@ -563,14 +567,7 @@ ParameterIdentification <- R6::R6Class(
       # Iterate through the values and update current parameter values. The
       # order of the values corresponds to the order of `PIParameters` in the
       # parameters list.
-      for (idx in seq_along(currVals)) {
-        piParameter <- private$.piParameters[[idx]]
-        baseValue <- .toBaseValue(piParameter, currVals[[idx]])
-        for (parameter in piParameter$parameters) {
-          simId <- .getSimulationContainer(parameter)$id
-          private$.setVariableValue(simId, parameter, baseValue)
-        }
-      }
+      private$.applyParameterValues(currVals)
 
       ##### 2DO - implement Steady-State when issue in Core is fixed
       # # Simulate steady-states if specified

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -781,7 +781,9 @@ ParameterIdentification <- R6::R6Class(
     #'   [`ospsuite::loadSimulation()`] to load simulation files.
     #' @param parameters A `PIParameters` or list of `PIParameters` objects
     #'   specifying the model parameters to optimize. Each `PIParameters` object
-    #'   may group one or more underlying model parameters. See
+    #'   may group one or more underlying model parameters, and its values are
+    #'   converted from its `$unit` to the base unit before they are applied to
+    #'   the model. See
     #'   [`ospsuite.parameteridentification::PIParameters`] for details.
     #' @param configuration (Optional) A `PIConfiguration` object specifying
     #'   algorithm, CI method, and objective function settings. Defaults to a
@@ -1025,7 +1027,9 @@ ParameterIdentification <- R6::R6Class(
     #'   data.
     #'
     #' @param par Optional parameter values for simulations, in the order of
-    #'   `ParameterIdentification$parameters`. Use current values if `NULL`.
+    #'   `ParameterIdentification$parameters`. Interpreted in each
+    #'   `PIParameters$unit` and converted to the base unit before being applied
+    #'   to the model. Use current values if `NULL`.
     #' @return A list of `patchwork` objects (one per output mapping), showing:
     #' - Individual time profiles
     #' - Predicted vs. observed values
@@ -1144,9 +1148,9 @@ ParameterIdentification <- R6::R6Class(
     #' initialize better starting values.
     #'
     #' @param lower Numeric vector of parameter lower bounds, defaulting to
-    #'   `PIParameter` minimum values.
+    #'   `PIParameter` minimum values. Interpreted in each `PIParameters$unit`.
     #' @param upper Numeric vector of parameter upper bounds, defaulting to
-    #'   `PIParameter` maximum values.
+    #'   `PIParameter` maximum values. Interpreted in each `PIParameters$unit`.
     #' @param logScaleFlag Logical scalar or vector; determines if grid points
     #'   are spaced logarithmically. Default is `FALSE`.
     #' @param totalEvaluations Integer specifying the total grid points. Default
@@ -1275,8 +1279,9 @@ ParameterIdentification <- R6::R6Class(
     #' `Inf` to the corresponding `ofv` cell.
     #'
     #' @param par Numeric vector of parameter values, one for each
-    #'   `PIParameter`. Defaults to current parameter values if `NULL`,
-    #'   not numeric, or of mismatched length.
+    #'   `PIParameter`, interpreted in each `PIParameters$unit`. Defaults to
+    #'   current parameter values if `NULL`, not numeric, or of mismatched
+    #'   length.
     #' @param boundFactor Numeric scalar. A value of `0.1` (default) means
     #'   bounds extend ±10% around `par` for each parameter.
     #' @param totalEvaluations Integer specifying the number of grid points

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -125,7 +125,7 @@ ParameterIdentification <- R6::R6Class(
 
     # Applies a vector of optimizer values, one entry per `PIParameters` group,
     # to every underlying model parameter. Values arrive in each group's
-    # `$unit`; `addRunValues()` reads base units, so they are converted here.
+    # `$unit`. `addRunValues()` reads base units, so they are converted here.
     # This is the only place that writes into the variable buckets.
     .applyParameterValues = function(values) {
       for (idx in seq_along(values)) {

--- a/R/ParameterIdentification.R
+++ b/R/ParameterIdentification.R
@@ -128,6 +128,12 @@ ParameterIdentification <- R6::R6Class(
     # `$unit`. `addRunValues()` reads base units, so they are converted here.
     # This is the only place that writes into the variable buckets.
     .applyParameterValues = function(values) {
+      if (length(values) != length(private$.piParameters)) {
+        stop(messages$errorParameterValuesLengthMismatch(
+          length(private$.piParameters),
+          length(values)
+        ))
+      }
       for (idx in seq_along(values)) {
         piParameter <- private$.piParameters[[idx]]
         baseValue <- .toBaseValue(piParameter, values[[idx]])
@@ -1148,14 +1154,14 @@ ParameterIdentification <- R6::R6Class(
     #' initialize better starting values.
     #'
     #' @param lower Numeric vector of parameter lower bounds, defaulting to
-    #'   `PIParameter` minimum values. Interpreted in each `PIParameters$unit`.
+    #'   `PIParameters` minimum values. Interpreted in each `PIParameters$unit`.
     #' @param upper Numeric vector of parameter upper bounds, defaulting to
-    #'   `PIParameter` maximum values. Interpreted in each `PIParameters$unit`.
+    #'   `PIParameters` maximum values. Interpreted in each `PIParameters$unit`.
     #' @param logScaleFlag Logical scalar or vector; determines if grid points
     #'   are spaced logarithmically. Default is `FALSE`.
     #' @param totalEvaluations Integer specifying the total grid points. Default
     #'   is 50.
-    #' @param setStartValue Logical. If `TRUE`, updates `PIParameter` starting
+    #' @param setStartValue Logical. If `TRUE`, updates `PIParameters` starting
     #'   values to the best grid point. Default is `FALSE`.
     #'
     #' @return A tibble where each row is a parameter combination and the
@@ -1260,7 +1266,7 @@ ParameterIdentification <- R6::R6Class(
     #' Calculate Objective Function Value (OFV) Profiles
     #'
     #' @description
-    #' Generates OFV profiles by varying each `PIParameter` independently while
+    #' Generates OFV profiles by varying each `PIParameters` independently while
     #' holding the others fixed at `par`. Useful as a post-optimization
     #' diagnostic: around a (local) minimum the OFV is expected to be roughly
     #' convex along each axis.
@@ -1279,7 +1285,7 @@ ParameterIdentification <- R6::R6Class(
     #' `Inf` to the corresponding `ofv` cell.
     #'
     #' @param par Numeric vector of parameter values, one for each
-    #'   `PIParameter`, interpreted in each `PIParameters$unit`. Defaults to
+    #'   `PIParameters`, interpreted in each `PIParameters$unit`. Defaults to
     #'   current parameter values if `NULL`, not numeric, or of mismatched
     #'   length.
     #' @param boundFactor Numeric scalar. A value of `0.1` (default) means
@@ -1287,7 +1293,7 @@ ParameterIdentification <- R6::R6Class(
     #' @param totalEvaluations Integer specifying the number of grid points
     #'   per parameter profile. Default is `20`.
     #'
-    #' @return A named list of tibbles, one element per `PIParameter`. List
+    #' @return A named list of tibbles, one element per `PIParameters`. List
     #'   names are the parameter paths (taken from `parameters[[1]]$path`).
     #'   Each tibble has two columns:
     #'   - a column named after the parameter path, holding the grid values;

--- a/R/messages.R
+++ b/R/messages.R
@@ -359,6 +359,12 @@ messages$errorPKMappingsEmpty <- function() {
   )
 }
 
+messages$errorParameterValuesLengthMismatch <- function(expected, actual) {
+  ospsuite.utils::cliFormat(
+    "Parameter values must supply one entry for each of the {expected} {.cls PIParameters} object{?s}, but {actual} {?was/were} given."
+  )
+}
+
 messages$errorMethodNotApplicableInPKMode <- function(methodName) {
   ospsuite.utils::cliFormat(
     "{.fn {methodName}} is not applicable for PK metric optimization."

--- a/R/utilities-quantity.R
+++ b/R/utilities-quantity.R
@@ -27,6 +27,25 @@
   )
 }
 
+#' Convert an optimization parameter value to its base unit
+#'
+#' `SimulationBatch$addRunValues()` reads its values as base units and converts
+#' nothing, while the optimizer works in `PIParameters$unit`.
+#'
+#' @param piParameter A `PIParameters` object.
+#' @param value Numeric value expressed in `piParameter$unit`.
+#'
+#' @return `value` expressed in the parameter's base unit.
+#' @keywords internal
+#' @noRd
+.toBaseValue <- function(piParameter, value) {
+  ospsuite::toBaseUnit(
+    quantityOrDimension = piParameter$parameters[[1]],
+    values = value,
+    unit = piParameter$unit
+  )
+}
+
 #' Validate observed data availability in `PIOutputMapping`
 #'
 #' Ensures each `PIOutputMapping` object has observed datasets. Throws an error

--- a/man/PIParameters.Rd
+++ b/man/PIParameters.Rd
@@ -26,7 +26,10 @@ specified by \verb{$unit}.}
     \item{\code{unit}}{Parameter value units. Changing the unit does NOT
 automatically adjust min/max/start values. Values are converted from
 this unit to the parameter's base unit before they are applied to the
-model.}
+model. With the \code{HJKB} algorithm, the declared unit also affects the
+search resolution because \code{HJKB} probes with absolute step sizes. See
+\code{vignette("user-guide", package = "ospsuite.parameteridentification")}
+for detail.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/PIParameters.Rd
+++ b/man/PIParameters.Rd
@@ -24,7 +24,9 @@ specified by \verb{$unit}.}
     \item{\code{maxValue}}{Highest permissible parameter value.}
 
     \item{\code{unit}}{Parameter value units. Changing the unit does NOT
-automatically adjust min/max/start values.}
+automatically adjust min/max/start values. Values are converted from
+this unit to the parameter's base unit before they are applied to the
+model.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/PIParameters.Rd
+++ b/man/PIParameters.Rd
@@ -27,9 +27,7 @@ specified by \verb{$unit}.}
 automatically adjust min/max/start values. Values are converted from
 this unit to the parameter's base unit before they are applied to the
 model. With the \code{HJKB} algorithm, the declared unit also affects the
-search resolution because \code{HJKB} probes with absolute step sizes. See
-\code{vignette("user-guide", package = "ospsuite.parameteridentification")}
-for detail.}
+search resolution because \code{HJKB} probes with absolute step sizes.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/ParameterIdentification.Rd
+++ b/man/ParameterIdentification.Rd
@@ -84,7 +84,9 @@ parameters specified in \code{parameters}. Use
 \code{\link[ospsuite:loadSimulation]{ospsuite::loadSimulation()}} to load simulation files.}
       \item{\code{parameters}}{A \code{PIParameters} or list of \code{PIParameters} objects
 specifying the model parameters to optimize. Each \code{PIParameters} object
-may group one or more underlying model parameters. See
+may group one or more underlying model parameters, and its values are
+converted from its \verb{$unit} to the base unit before they are applied to
+the model. See
 \code{\link{PIParameters}} for details.}
       \item{\code{outputMappings}}{(Optional) A \code{PIOutputMapping} or list of
 \code{PIOutputMapping} objects mapping model outputs to observed data.
@@ -163,7 +165,9 @@ data.
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{par}}{Optional parameter values for simulations, in the order of
-\code{ParameterIdentification$parameters}. Use current values if \code{NULL}.}
+\code{ParameterIdentification$parameters}. Interpreted in each
+\code{PIParameters$unit} and converted to the base unit before being applied
+to the model. Use current values if \code{NULL}.}
     }
     \if{html}{\out{</div>}}
   }
@@ -204,9 +208,9 @@ initialize better starting values.
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{lower}}{Numeric vector of parameter lower bounds, defaulting to
-\code{PIParameter} minimum values.}
+\code{PIParameter} minimum values. Interpreted in each \code{PIParameters$unit}.}
       \item{\code{upper}}{Numeric vector of parameter upper bounds, defaulting to
-\code{PIParameter} maximum values.}
+\code{PIParameter} maximum values. Interpreted in each \code{PIParameters$unit}.}
       \item{\code{logScaleFlag}}{Logical scalar or vector; determines if grid points
 are spaced logarithmically. Default is \code{FALSE}.}
       \item{\code{totalEvaluations}}{Integer specifying the total grid points. Default
@@ -244,8 +248,9 @@ convex along each axis.
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{par}}{Numeric vector of parameter values, one for each
-\code{PIParameter}. Defaults to current parameter values if \code{NULL},
-not numeric, or of mismatched length.}
+\code{PIParameter}, interpreted in each \code{PIParameters$unit}. Defaults to
+current parameter values if \code{NULL}, not numeric, or of mismatched
+length.}
       \item{\code{boundFactor}}{Numeric scalar. A value of \code{0.1} (default) means
 bounds extend ±10\% around \code{par} for each parameter.}
       \item{\code{totalEvaluations}}{Integer specifying the number of grid points

--- a/man/ParameterIdentification.Rd
+++ b/man/ParameterIdentification.Rd
@@ -208,14 +208,14 @@ initialize better starting values.
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{lower}}{Numeric vector of parameter lower bounds, defaulting to
-\code{PIParameter} minimum values. Interpreted in each \code{PIParameters$unit}.}
+\code{PIParameters} minimum values. Interpreted in each \code{PIParameters$unit}.}
       \item{\code{upper}}{Numeric vector of parameter upper bounds, defaulting to
-\code{PIParameter} maximum values. Interpreted in each \code{PIParameters$unit}.}
+\code{PIParameters} maximum values. Interpreted in each \code{PIParameters$unit}.}
       \item{\code{logScaleFlag}}{Logical scalar or vector; determines if grid points
 are spaced logarithmically. Default is \code{FALSE}.}
       \item{\code{totalEvaluations}}{Integer specifying the total grid points. Default
 is 50.}
-      \item{\code{setStartValue}}{Logical. If \code{TRUE}, updates \code{PIParameter} starting
+      \item{\code{setStartValue}}{Logical. If \code{TRUE}, updates \code{PIParameters} starting
 values to the best grid point. Default is \code{FALSE}.}
     }
     \if{html}{\out{</div>}}
@@ -231,7 +231,7 @@ Calculate Objective Function Value (OFV) Profiles
 \if{html}{\out{<a id="method-ParameterIdentification-calculateOFVProfiles"></a>}}
 \if{latex}{\out{\hypertarget{method-ParameterIdentification-calculateOFVProfiles}{}}}
 \subsection{\code{ParameterIdentification$calculateOFVProfiles()}}{
-  Generates OFV profiles by varying each \code{PIParameter} independently while
+  Generates OFV profiles by varying each \code{PIParameters} independently while
 holding the others fixed at \code{par}. Useful as a post-optimization
 diagnostic: around a (local) minimum the OFV is expected to be roughly
 convex along each axis.
@@ -248,7 +248,7 @@ convex along each axis.
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{par}}{Numeric vector of parameter values, one for each
-\code{PIParameter}, interpreted in each \code{PIParameters$unit}. Defaults to
+\code{PIParameters}, interpreted in each \code{PIParameters$unit}. Defaults to
 current parameter values if \code{NULL}, not numeric, or of mismatched
 length.}
       \item{\code{boundFactor}}{Numeric scalar. A value of \code{0.1} (default) means
@@ -273,7 +273,7 @@ parameters held at their \code{par} values. Failed simulations contribute
 \code{Inf} to the corresponding \code{ofv} cell.
   }
   \subsection{Returns}{
-    A named list of tibbles, one element per \code{PIParameter}. List
+    A named list of tibbles, one element per \code{PIParameters}. List
 names are the parameter paths (taken from \code{parameters[[1]]$path}).
 Each tibble has two columns:
 \itemize{

--- a/tests/testthat/_snaps/pid-aux.md
+++ b/tests/testthat/_snaps/pid-aux.md
@@ -1,3 +1,19 @@
+# plotResults() errors when `par` length differs from parameter count
+
+    Code
+      twoParameterTask$plotResults(1.2)
+    Condition
+      Error in `private$.applyParameterValues()`:
+      ! Parameter values must supply one entry for each of the 2 <PIParameters> objects, but 1 was given.
+
+---
+
+    Code
+      twoParameterTask$plotResults(c(1.2, 3.4, 5.6))
+    Condition
+      Error in `private$.applyParameterValues()`:
+      ! Parameter values must supply one entry for each of the 2 <PIParameters> objects, but 3 were given.
+
 # gridSearch() works with multiple parameters and default settings
 
     Code

--- a/tests/testthat/_snaps/pid-aux/after-estimation.svg
+++ b/tests/testthat/_snaps/pid-aux/after-estimation.svg
@@ -238,7 +238,7 @@
 <polyline points='224.23,511.19 226.97,511.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='224.23,471.53 226.97,471.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='224.23,431.87 226.97,431.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text transform='translate(197.31,478.97) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='44.03px' lengthAdjust='spacingAndGlyphs'>residuals</text>
+<text transform='translate(197.31,478.97) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='73.98px' lengthAdjust='spacingAndGlyphs'>residuals [mg/l]</text>
 <text transform='translate(209.19,478.97) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='100.29px' lengthAdjust='spacingAndGlyphs'>predicted - observed</text>
 <polyline points='236.74,542.37 236.74,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='324.94,542.37 324.94,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />

--- a/tests/testthat/_snaps/pid-aux/before-estimation.svg
+++ b/tests/testthat/_snaps/pid-aux/before-estimation.svg
@@ -235,7 +235,7 @@
 <polyline points='222.76,493.63 225.50,493.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='222.76,459.31 225.50,459.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='222.76,424.99 225.50,424.99 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text transform='translate(198.77,478.97) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='44.03px' lengthAdjust='spacingAndGlyphs'>residuals</text>
+<text transform='translate(198.77,478.97) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='73.98px' lengthAdjust='spacingAndGlyphs'>residuals [mg/l]</text>
 <text transform='translate(210.65,478.97) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='100.29px' lengthAdjust='spacingAndGlyphs'>predicted - observed</text>
 <polyline points='235.28,542.37 235.28,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='323.47,542.37 323.47,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />

--- a/tests/testthat/_snaps/pid-aux/custom-parameter.svg
+++ b/tests/testthat/_snaps/pid-aux/custom-parameter.svg
@@ -238,7 +238,7 @@
 <polyline points='224.23,516.91 226.97,516.91 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='224.23,481.83 226.97,481.83 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='224.23,446.76 226.97,446.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text transform='translate(197.31,478.97) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='44.03px' lengthAdjust='spacingAndGlyphs'>residuals</text>
+<text transform='translate(197.31,478.97) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='73.98px' lengthAdjust='spacingAndGlyphs'>residuals [mg/l]</text>
 <text transform='translate(209.19,478.97) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='100.29px' lengthAdjust='spacingAndGlyphs'>predicted - observed</text>
 <polyline points='236.74,542.37 236.74,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='324.94,542.37 324.94,539.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />

--- a/tests/testthat/helper-for-tests.R
+++ b/tests/testthat/helper-for-tests.R
@@ -352,7 +352,7 @@ outputMapping_500mg$addObservedDataSets(
   testObservedData()$`AciclovirLaskinData.Laskin 1982.Group A`
 )
 
-# State-variable parameter fixtures (issue #156)
+# State-variable parameter fixtures
 
 # Aciclovir state-variable (RHS-defined) parameter, dimension Volume (~0.045 L).
 stateVariableParameterPath <- "Organism|Lumen|Stomach|Liquid"

--- a/tests/testthat/test-pi-pk-mappings.R
+++ b/tests/testthat/test-pi-pk-mappings.R
@@ -321,6 +321,7 @@ test_that("run() applies a non-base parameter unit in PK mode (#298)", {
     doseTask(ospUnits$Mass$mg, 250, 100, 1000)$run()
   )
 
+  expect_true(is.finite(baseResult$toDataFrame()$achievedValue))
   expect_equal(
     milligramResult$toDataFrame()$achievedValue,
     baseResult$toDataFrame()$achievedValue,

--- a/tests/testthat/test-pi-pk-mappings.R
+++ b/tests/testthat/test-pi-pk-mappings.R
@@ -275,3 +275,55 @@ test_that(".getPKValues routes a state-variable parameter as a molecule (#156)",
   )
   expect_true(is.finite(pkValues[[1]]))
 })
+
+test_that("run() applies a non-base parameter unit in PK mode (#298)", {
+  pkmlPath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  dosePath <- "Events|IV 250mg 10min|Application_1|ProtocolSchemaItem|Dose"
+  outputPath <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
+
+  # Each task loads its own simulation: earlier run()s in this file mutate the
+  # shared memoized simulation's Dose through .applyFinalValues(), which would
+  # invalidate the equality oracle.
+  doseTask <- function(unit, startValue, minValue, maxValue) {
+    sim <- loadSimulation(pkmlPath, loadFromCache = FALSE, addToCache = FALSE)
+    piParameter <- PIParameters$new(
+      parameters = list(getParameter(dosePath, container = sim))
+    )
+    piParameter$unit <- unit
+    # Start value first, then max, then min: the bound setters cross-validate
+    # against startValue and against the base-unit bounds left from
+    # construction, because changing $unit does not rescale them (#246).
+    piParameter$startValue <- startValue
+    piParameter$maxValue <- maxValue
+    piParameter$minValue <- minValue
+
+    quantity <- getQuantity(outputPath, container = sim)
+    mapping <- PKOutputMapping$new(
+      quantity = quantity,
+      pkParameter = "C_max",
+      targetValue = 30,
+      targetUnit = quantity$unit
+    )
+
+    ParameterIdentification$new(
+      simulations = sim,
+      parameters = piParameter,
+      pkOutputMappings = mapping,
+      configuration = lowIterPiConfiguration(iter = 1)
+    )
+  }
+
+  # 2.5e-4 kg is 250 mg, and the bounds bracket it identically in both units.
+  baseResult <- suppressMessages(
+    doseTask(ospUnits$Mass$kg, 2.5e-4, 1e-4, 1e-3)$run()
+  )
+  milligramResult <- suppressMessages(
+    doseTask(ospUnits$Mass$mg, 250, 100, 1000)$run()
+  )
+
+  expect_equal(
+    milligramResult$toDataFrame()$achievedValue,
+    baseResult$toDataFrame()$achievedValue,
+    tolerance = 1e-6
+  )
+})

--- a/tests/testthat/test-pi-pk-mappings.R
+++ b/tests/testthat/test-pi-pk-mappings.R
@@ -238,7 +238,7 @@ test_that(".getPKValues uses each mapping's own simulation batch, not always the
   )
 })
 
-test_that(".getPKValues routes a state-variable parameter as a molecule (#156)", {
+test_that(".getPKValues routes a state-variable parameter as a molecule", {
   sim <- loadSimulation(
     system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
   )
@@ -276,23 +276,21 @@ test_that(".getPKValues routes a state-variable parameter as a molecule (#156)",
   expect_true(is.finite(pkValues[[1]]))
 })
 
-test_that("run() applies a non-base parameter unit in PK mode (#298)", {
+test_that("run() applies a non-base parameter unit in PK mode", {
   pkmlPath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
   dosePath <- "Events|IV 250mg 10min|Application_1|ProtocolSchemaItem|Dose"
   outputPath <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
 
-  # Each task loads its own simulation: earlier run()s in this file mutate the
-  # shared memoized simulation's Dose through .applyFinalValues(), which would
-  # invalidate the equality oracle.
+  # Own simulation per task: earlier run()s mutate the cached simulation's Dose
+  # via .applyFinalValues(), which would break the equality oracle.
   doseTask <- function(unit, startValue, minValue, maxValue) {
     sim <- loadSimulation(pkmlPath, loadFromCache = FALSE, addToCache = FALSE)
     piParameter <- PIParameters$new(
       parameters = list(getParameter(dosePath, container = sim))
     )
     piParameter$unit <- unit
-    # Start value first, then max, then min: the bound setters cross-validate
-    # against startValue and against the base-unit bounds left from
-    # construction, because changing $unit does not rescale them (#246).
+    # Start, then max, then min: $unit does not rescale the values left from
+    # construction, and the bound setters cross-validate against them.
     piParameter$startValue <- startValue
     piParameter$maxValue <- maxValue
     piParameter$minValue <- minValue

--- a/tests/testthat/test-pid-aux.R
+++ b/tests/testthat/test-pid-aux.R
@@ -19,6 +19,19 @@ test_that("plotResults() generates expected plot with parameter input", {
   vdiffr::expect_doppelganger("custom-parameter", piTask$plotResults(1.2)[[1]])
 })
 
+test_that("plotResults() errors when `par` length differs from parameter count", {
+  twoParameterTask <- ParameterIdentification$new(
+    simulations = sim_250mg,
+    parameters = list(piParameterLipo_250mg, piParameterCl_250mg),
+    outputMappings = outputMapping_250mg
+  )
+  expect_snapshot(twoParameterTask$plotResults(1.2), error = TRUE)
+  expect_snapshot(
+    twoParameterTask$plotResults(c(1.2, 3.4, 5.6)),
+    error = TRUE
+  )
+})
+
 
 # Grid Search
 
@@ -83,7 +96,7 @@ test_that("gridSearch() returns `Inf` upon simulation failure", {
   expect_snapshot(gridSearchResults$ofv)
 })
 
-test_that("gridSearch OFVs are invariant to a non-base parameter unit (#298)", {
+test_that("gridSearch OFVs are invariant to a non-base parameter unit", {
   pkmlPath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
   clPath <- "Neighborhoods|Kidney_pls_Kidney_ur|Aciclovir|Renal Clearances-TS-Aciclovir|TSspec"
   outputPath <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"

--- a/tests/testthat/test-pid-aux.R
+++ b/tests/testthat/test-pid-aux.R
@@ -83,6 +83,53 @@ test_that("gridSearch() returns `Inf` upon simulation failure", {
   expect_snapshot(gridSearchResults$ofv)
 })
 
+test_that("gridSearch OFVs are invariant to a non-base parameter unit (#298)", {
+  pkmlPath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  clPath <- "Neighborhoods|Kidney_pls_Kidney_ur|Aciclovir|Renal Clearances-TS-Aciclovir|TSspec"
+  outputPath <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
+  observed <- testObservedData()$`AciclovirLaskinData.Laskin 1982.Group A`
+
+  # Each task loads its own simulation and builds its own PIParameters, so that
+  # assigning $unit cannot leak into the shared module-level fixtures.
+  clearanceTask <- function(unit) {
+    sim <- loadSimulation(pkmlPath, loadFromCache = FALSE, addToCache = FALSE)
+    piParameter <- PIParameters$new(
+      parameters = list(getParameter(clPath, container = sim))
+    )
+    piParameter$unit <- unit
+
+    mapping <- PIOutputMapping$new(
+      quantity = getQuantity(outputPath, container = sim)
+    )
+    mapping$addObservedDataSets(observed)
+
+    ParameterIdentification$new(
+      simulations = sim,
+      parameters = piParameter,
+      outputMappings = mapping
+    )
+  }
+
+  # [1e-4, 1e-3] 1/min and [6e-3, 6e-2] 1/h are the same physical interval.
+  # Explicit bounds mean the stale base-unit min/max are never consulted.
+  baseGrid <- suppressMessages(
+    clearanceTask(ospUnits$`Inversed time`$`1/min`)$gridSearch(
+      lower = 1e-4,
+      upper = 1e-3,
+      totalEvaluations = 3
+    )
+  )
+  hourGrid <- suppressMessages(
+    clearanceTask(ospUnits$`Inversed time`$`1/h`)$gridSearch(
+      lower = 1e-4 * 60,
+      upper = 1e-3 * 60,
+      totalEvaluations = 3
+    )
+  )
+
+  expect_equal(hourGrid$ofv, baseGrid$ofv, tolerance = 1e-6)
+})
+
 
 # Calculate OFV Profiles
 

--- a/tests/testthat/test-pid-run.R
+++ b/tests/testthat/test-pid-run.R
@@ -62,7 +62,7 @@ test_that("run() stores best running cost in costDetails", {
   expect_equal(resultList$objectiveValue, resultList$costDetails$modelCost)
 })
 
-test_that("run() succeeds with a state-variable optimization parameter (#156)", {
+test_that("run() succeeds with a state-variable optimization parameter", {
   piTask <- testStateVariableMixedTask()
   piTask$configuration <- lowIterPiConfiguration()
   piTask$configuration$autoEstimateCI <- FALSE
@@ -170,7 +170,7 @@ test_that("run() works with two datasets and individual weights", {
 })
 
 test_that("run() reports the estimate in the declared unit and applies the matching base value", {
-  # Verifies the reporting contract, not the #298 conversion. The estimate is
+  # Verifies the reporting contract, not the unit conversion. The estimate is
   # reported in $unit and .applyFinalValues() writes the matching base value.
   # It cannot detect a conversion regression, because setValue() converts
   # correctly regardless. The conversion itself is covered by the gridSearch
@@ -190,9 +190,8 @@ test_that("run() reports the estimate in the declared unit and applies the match
     parameters = list(ospsuite::getParameter(clPath, container = sim))
   )
   piParameter$unit <- ospUnits$`Inversed time`$`1/h`
-  # Start value first, then max, then min: the bound setters cross-validate
-  # against startValue and against the base-unit bounds left from
-  # construction, because changing $unit does not rescale them (#246).
+  # Start, then max, then min: $unit does not rescale the values left from
+  # construction, and the bound setters cross-validate against them.
   piParameter$startValue <- 56.4
   piParameter$maxValue <- 100
   piParameter$minValue <- 10

--- a/tests/testthat/test-pid-run.R
+++ b/tests/testthat/test-pid-run.R
@@ -168,3 +168,50 @@ test_that("run() works with two datasets and individual weights", {
   suppressMessages(result <- piTask$run())
   expect_equal(result$toList()$objectiveValue, 4486.392, tolerance = 0.1)
 })
+
+test_that("gridSearch OFVs are invariant to a non-base parameter unit (#298)", {
+  pkmlPath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  clPath <- "Neighborhoods|Kidney_pls_Kidney_ur|Aciclovir|Renal Clearances-TS-Aciclovir|TSspec"
+  outputPath <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
+  observed <- testObservedData()$`AciclovirLaskinData.Laskin 1982.Group A`
+
+  # Each task loads its own simulation and builds its own PIParameters, so that
+  # assigning $unit cannot leak into the shared module-level fixtures.
+  clearanceTask <- function(unit) {
+    sim <- loadSimulation(pkmlPath, loadFromCache = FALSE, addToCache = FALSE)
+    piParameter <- PIParameters$new(
+      parameters = list(getParameter(clPath, container = sim))
+    )
+    piParameter$unit <- unit
+
+    mapping <- PIOutputMapping$new(
+      quantity = getQuantity(outputPath, container = sim)
+    )
+    mapping$addObservedDataSets(observed)
+
+    ParameterIdentification$new(
+      simulations = sim,
+      parameters = piParameter,
+      outputMappings = mapping
+    )
+  }
+
+  # [1e-4, 1e-3] 1/min and [6e-3, 6e-2] 1/h are the same physical interval.
+  # Explicit bounds mean the stale base-unit min/max are never consulted.
+  baseGrid <- suppressMessages(
+    clearanceTask(ospUnits$`Inversed time`$`1/min`)$gridSearch(
+      lower = 1e-4,
+      upper = 1e-3,
+      totalEvaluations = 3
+    )
+  )
+  hourGrid <- suppressMessages(
+    clearanceTask(ospUnits$`Inversed time`$`1/h`)$gridSearch(
+      lower = 1e-4 * 60,
+      upper = 1e-3 * 60,
+      totalEvaluations = 3
+    )
+  )
+
+  expect_equal(hourGrid$ofv, baseGrid$ofv, tolerance = 1e-6)
+})

--- a/tests/testthat/test-pid-run.R
+++ b/tests/testthat/test-pid-run.R
@@ -273,3 +273,62 @@ test_that("a non-base state-variable unit reaches the molecules bucket in base u
     stateVariableParameterPath %in% names(priv$.variableParameters[[simId]])
   )
 })
+
+test_that("run() reports the estimate in the declared unit and applies the matching base value", {
+  # Verifies the reporting contract, not the #298 conversion. The estimate is
+  # reported in $unit and .applyFinalValues() writes the matching base value.
+  # It cannot detect a conversion regression, because setValue() converts
+  # correctly regardless. The conversion itself is covered by the gridSearch
+  # and molecules bucket tests above.
+  pkmlPath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  clPath <- "Neighborhoods|Kidney_pls_Kidney_ur|Aciclovir|Renal Clearances-TS-Aciclovir|TSspec"
+  outputPath <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
+
+  # Own simulation and PIParameters, so that assigning $unit cannot leak into
+  # the shared module-level fixtures used by unrelated snapshot tests.
+  sim <- ospsuite::loadSimulation(
+    pkmlPath,
+    loadFromCache = FALSE,
+    addToCache = FALSE
+  )
+  piParameter <- PIParameters$new(
+    parameters = list(ospsuite::getParameter(clPath, container = sim))
+  )
+  piParameter$unit <- ospUnits$`Inversed time`$`1/h`
+  # Start value first, then max, then min: the bound setters cross-validate
+  # against startValue and against the base-unit bounds left from
+  # construction, because changing $unit does not rescale them (#246).
+  piParameter$startValue <- 56.4
+  piParameter$maxValue <- 100
+  piParameter$minValue <- 10
+
+  mapping <- PIOutputMapping$new(
+    quantity = ospsuite::getQuantity(outputPath, container = sim)
+  )
+  mapping$addObservedDataSets(
+    testObservedData()$`AciclovirLaskinData.Laskin 1982.Group A`
+  )
+
+  piTask <- ParameterIdentification$new(
+    simulations = sim,
+    parameters = piParameter,
+    outputMappings = mapping,
+    configuration = lowIterPiConfiguration(iter = 1)
+  )
+  piTask$configuration$autoEstimateCI <- FALSE
+
+  suppressMessages(piResult <- piTask$run())
+  resultRow <- piResult$toDataFrame()
+  modelParameter <- ospsuite::getParameter(clPath, container = sim)
+
+  expect_equal(resultRow$unit, ospUnits$`Inversed time`$`1/h`)
+  expect_equal(
+    modelParameter$value,
+    ospsuite::toBaseUnit(
+      quantityOrDimension = modelParameter,
+      values = resultRow$estimate,
+      unit = resultRow$unit
+    ),
+    tolerance = 1e-6
+  )
+})

--- a/tests/testthat/test-pid-run.R
+++ b/tests/testthat/test-pid-run.R
@@ -169,111 +169,6 @@ test_that("run() works with two datasets and individual weights", {
   expect_equal(result$toList()$objectiveValue, 4486.392, tolerance = 0.1)
 })
 
-test_that("gridSearch OFVs are invariant to a non-base parameter unit (#298)", {
-  pkmlPath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
-  clPath <- "Neighborhoods|Kidney_pls_Kidney_ur|Aciclovir|Renal Clearances-TS-Aciclovir|TSspec"
-  outputPath <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
-  observed <- testObservedData()$`AciclovirLaskinData.Laskin 1982.Group A`
-
-  # Each task loads its own simulation and builds its own PIParameters, so that
-  # assigning $unit cannot leak into the shared module-level fixtures.
-  clearanceTask <- function(unit) {
-    sim <- loadSimulation(pkmlPath, loadFromCache = FALSE, addToCache = FALSE)
-    piParameter <- PIParameters$new(
-      parameters = list(getParameter(clPath, container = sim))
-    )
-    piParameter$unit <- unit
-
-    mapping <- PIOutputMapping$new(
-      quantity = getQuantity(outputPath, container = sim)
-    )
-    mapping$addObservedDataSets(observed)
-
-    ParameterIdentification$new(
-      simulations = sim,
-      parameters = piParameter,
-      outputMappings = mapping
-    )
-  }
-
-  # [1e-4, 1e-3] 1/min and [6e-3, 6e-2] 1/h are the same physical interval.
-  # Explicit bounds mean the stale base-unit min/max are never consulted.
-  baseGrid <- suppressMessages(
-    clearanceTask(ospUnits$`Inversed time`$`1/min`)$gridSearch(
-      lower = 1e-4,
-      upper = 1e-3,
-      totalEvaluations = 3
-    )
-  )
-  hourGrid <- suppressMessages(
-    clearanceTask(ospUnits$`Inversed time`$`1/h`)$gridSearch(
-      lower = 1e-4 * 60,
-      upper = 1e-3 * 60,
-      totalEvaluations = 3
-    )
-  )
-
-  expect_equal(hourGrid$ofv, baseGrid$ofv, tolerance = 1e-6)
-})
-
-test_that("a non-base state-variable unit reaches the molecules bucket in base units (#298)", {
-  sim <- loadSimulation(
-    system.file("extdata", "Aciclovir.pkml", package = "ospsuite"),
-    loadFromCache = FALSE,
-    addToCache = FALSE
-  )
-
-  # Organism|Lumen|Stomach|Liquid is RHS-defined, so .setVariableValue() routes
-  # it into the molecules bucket rather than the parameters bucket. Its base
-  # unit is l, so values declared in ml must arrive divided by 1000.
-  piParameter <- PIParameters$new(
-    parameters = list(getParameter(stateVariableParameterPath, container = sim))
-  )
-  piParameter$unit <- ospUnits$Volume$ml
-  # Start value first, then max, then min: the bound setters cross-validate
-  # against startValue and against the base-unit bounds left from construction,
-  # because changing $unit does not rescale them (#246).
-  piParameter$startValue <- 45
-  piParameter$maxValue <- 450
-  piParameter$minValue <- 4.5
-
-  mapping <- PIOutputMapping$new(
-    quantity = getQuantity(
-      "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
-      container = sim
-    )
-  )
-  mapping$addObservedDataSets(
-    testObservedData()$`AciclovirLaskinData.Laskin 1982.Group A`
-  )
-
-  task <- ParameterIdentification$new(
-    simulations = sim,
-    parameters = piParameter,
-    outputMappings = mapping
-  )
-  priv <- task$.__enclos_env__$private
-  priv$.batchInitialization()
-  simId <- names(priv$.simulations)[[1]]
-
-  # .batchInitialization() seeds the start value: 45 ml is 0.045 l.
-  expect_equal(
-    priv$.variableMolecules[[simId]][[stateVariableParameterPath]],
-    0.045
-  )
-
-  # .evaluate() deposits a trial value: 50 ml is 0.05 l.
-  suppressMessages(priv$.evaluate(50))
-  expect_equal(
-    priv$.variableMolecules[[simId]][[stateVariableParameterPath]],
-    0.05
-  )
-
-  expect_false(
-    stateVariableParameterPath %in% names(priv$.variableParameters[[simId]])
-  )
-})
-
 test_that("run() reports the estimate in the declared unit and applies the matching base value", {
   # Verifies the reporting contract, not the #298 conversion. The estimate is
   # reported in $unit and .applyFinalValues() writes the matching base value.
@@ -322,13 +217,11 @@ test_that("run() reports the estimate in the declared unit and applies the match
   modelParameter <- ospsuite::getParameter(clPath, container = sim)
 
   expect_equal(resultRow$unit, ospUnits$`Inversed time`$`1/h`)
+  # Independent oracle: 1/h to 1/min is a factor of 60, computed here rather
+  # than by re-using the conversion the implementation delegates to (T-6).
   expect_equal(
     modelParameter$value,
-    ospsuite::toBaseUnit(
-      quantityOrDimension = modelParameter,
-      values = resultRow$estimate,
-      unit = resultRow$unit
-    ),
+    resultRow$estimate / 60,
     tolerance = 1e-6
   )
 })

--- a/tests/testthat/test-pid-run.R
+++ b/tests/testthat/test-pid-run.R
@@ -215,3 +215,61 @@ test_that("gridSearch OFVs are invariant to a non-base parameter unit (#298)", {
 
   expect_equal(hourGrid$ofv, baseGrid$ofv, tolerance = 1e-6)
 })
+
+test_that("a non-base state-variable unit reaches the molecules bucket in base units (#298)", {
+  sim <- loadSimulation(
+    system.file("extdata", "Aciclovir.pkml", package = "ospsuite"),
+    loadFromCache = FALSE,
+    addToCache = FALSE
+  )
+
+  # Organism|Lumen|Stomach|Liquid is RHS-defined, so .setVariableValue() routes
+  # it into the molecules bucket rather than the parameters bucket. Its base
+  # unit is l, so values declared in ml must arrive divided by 1000.
+  piParameter <- PIParameters$new(
+    parameters = list(getParameter(stateVariableParameterPath, container = sim))
+  )
+  piParameter$unit <- ospUnits$Volume$ml
+  # Start value first, then max, then min: the bound setters cross-validate
+  # against startValue and against the base-unit bounds left from construction,
+  # because changing $unit does not rescale them (#246).
+  piParameter$startValue <- 45
+  piParameter$maxValue <- 450
+  piParameter$minValue <- 4.5
+
+  mapping <- PIOutputMapping$new(
+    quantity = getQuantity(
+      "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
+      container = sim
+    )
+  )
+  mapping$addObservedDataSets(
+    testObservedData()$`AciclovirLaskinData.Laskin 1982.Group A`
+  )
+
+  task <- ParameterIdentification$new(
+    simulations = sim,
+    parameters = piParameter,
+    outputMappings = mapping
+  )
+  priv <- task$.__enclos_env__$private
+  priv$.batchInitialization()
+  simId <- names(priv$.simulations)[[1]]
+
+  # .batchInitialization() seeds the start value: 45 ml is 0.045 l.
+  expect_equal(
+    priv$.variableMolecules[[simId]][[stateVariableParameterPath]],
+    0.045
+  )
+
+  # .evaluate() deposits a trial value: 50 ml is 0.05 l.
+  suppressMessages(priv$.evaluate(50))
+  expect_equal(
+    priv$.variableMolecules[[simId]][[stateVariableParameterPath]],
+    0.05
+  )
+
+  expect_false(
+    stateVariableParameterPath %in% names(priv$.variableParameters[[simId]])
+  )
+})

--- a/tests/testthat/test-utilities-objective-function.R
+++ b/tests/testthat/test-utilities-objective-function.R
@@ -414,7 +414,7 @@ currStartValues <- function(task) {
   vapply(task$parameters, function(p) p$startValue, numeric(1))
 }
 
-# state-variable parameter routing (issue #156)
+# state-variable parameter routing
 
 test_that("fixture state-variable path is classified as a state variable", {
   sim <- loadSimulation(
@@ -472,7 +472,7 @@ test_that("objective function delivers the state-variable value into the molecul
   )
 })
 
-test_that("a non-base state-variable unit reaches the molecules bucket in base units (#298)", {
+test_that("a non-base state-variable unit reaches the molecules bucket in base units", {
   sim <- loadSimulation(
     system.file("extdata", "Aciclovir.pkml", package = "ospsuite"),
     loadFromCache = FALSE,
@@ -486,9 +486,8 @@ test_that("a non-base state-variable unit reaches the molecules bucket in base u
     parameters = list(getParameter(stateVariableParameterPath, container = sim))
   )
   piParameter$unit <- ospUnits$Volume$ml
-  # Start value first, then max, then min: the bound setters cross-validate
-  # against startValue and against the base-unit bounds left from construction,
-  # because changing $unit does not rescale them (#246).
+  # Start, then max, then min: $unit does not rescale the values left from
+  # construction, and the bound setters cross-validate against them.
   piParameter$startValue <- 45
   piParameter$maxValue <- 450
   piParameter$minValue <- 4.5
@@ -528,6 +527,68 @@ test_that("a non-base state-variable unit reaches the molecules bucket in base u
   expect_false(
     stateVariableParameterPath %in% names(priv$.variableParameters[[simId]])
   )
+})
+
+test_that("a grouped parameter spanning two simulations is seeded in base units", {
+  clPath <- "Neighborhoods|Kidney_pls_Kidney_ur|Aciclovir|Renal Clearances-TS-Aciclovir|TSspec"
+  outputPath <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
+
+  # Two separately loaded simulations get distinct IDs, so the single converted
+  # value fans out into two variable buckets. Own simulations, so that assigning
+  # $unit cannot leak into the shared module-level fixtures.
+  simulations <- replicate(
+    2,
+    loadSimulation(
+      system.file("extdata", "Aciclovir.pkml", package = "ospsuite"),
+      loadFromCache = FALSE,
+      addToCache = FALSE
+    ),
+    simplify = FALSE
+  )
+
+  piParameter <- PIParameters$new(
+    parameters = lapply(simulations, function(sim) {
+      getParameter(clPath, container = sim)
+    })
+  )
+  piParameter$unit <- ospUnits$`Inversed time`$`1/h`
+  # Start, then max, then min: $unit does not rescale the values left from
+  # construction, and the bound setters cross-validate against them.
+  piParameter$startValue <- 6
+  piParameter$maxValue <- 60
+  piParameter$minValue <- 0.6
+
+  mappings <- lapply(simulations, function(sim) {
+    mapping <- PIOutputMapping$new(
+      quantity = getQuantity(outputPath, container = sim)
+    )
+    mapping$addObservedDataSets(
+      testObservedData()$`AciclovirLaskinData.Laskin 1982.Group A`
+    )
+    mapping
+  })
+
+  task <- ParameterIdentification$new(
+    simulations = simulations,
+    parameters = piParameter,
+    outputMappings = mappings
+  )
+  priv <- task$.__enclos_env__$private
+  priv$.batchInitialization()
+  simIds <- names(priv$.simulations)
+
+  expect_length(simIds, 2)
+  # Independent oracle: 1/h to 1/min is a factor of 60, so the start value of
+  # 6 1/h must reach both simulations as 0.1 1/min.
+  for (simId in simIds) {
+    expect_equal(priv$.variableParameters[[simId]][[clPath]], 0.1)
+  }
+
+  # .evaluate() deposits a trial value: 30 1/h is 0.5 1/min in both buckets.
+  suppressMessages(priv$.evaluate(30))
+  for (simId in simIds) {
+    expect_equal(priv$.variableParameters[[simId]][[clPath]], 0.5)
+  }
 })
 
 test_that("objective function runs with only a state-variable parameter", {

--- a/tests/testthat/test-utilities-objective-function.R
+++ b/tests/testthat/test-utilities-objective-function.R
@@ -472,6 +472,64 @@ test_that("objective function delivers the state-variable value into the molecul
   )
 })
 
+test_that("a non-base state-variable unit reaches the molecules bucket in base units (#298)", {
+  sim <- loadSimulation(
+    system.file("extdata", "Aciclovir.pkml", package = "ospsuite"),
+    loadFromCache = FALSE,
+    addToCache = FALSE
+  )
+
+  # Organism|Lumen|Stomach|Liquid is RHS-defined, so .setVariableValue() routes
+  # it into the molecules bucket rather than the parameters bucket. Its base
+  # unit is l, so values declared in ml must arrive divided by 1000.
+  piParameter <- PIParameters$new(
+    parameters = list(getParameter(stateVariableParameterPath, container = sim))
+  )
+  piParameter$unit <- ospUnits$Volume$ml
+  # Start value first, then max, then min: the bound setters cross-validate
+  # against startValue and against the base-unit bounds left from construction,
+  # because changing $unit does not rescale them (#246).
+  piParameter$startValue <- 45
+  piParameter$maxValue <- 450
+  piParameter$minValue <- 4.5
+
+  mapping <- PIOutputMapping$new(
+    quantity = getQuantity(
+      "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
+      container = sim
+    )
+  )
+  mapping$addObservedDataSets(
+    testObservedData()$`AciclovirLaskinData.Laskin 1982.Group A`
+  )
+
+  task <- ParameterIdentification$new(
+    simulations = sim,
+    parameters = piParameter,
+    outputMappings = mapping
+  )
+  priv <- task$.__enclos_env__$private
+  priv$.batchInitialization()
+  simId <- names(priv$.simulations)[[1]]
+
+  # .batchInitialization() seeds the start value: 45 ml is 0.045 l.
+  expect_equal(
+    priv$.variableMolecules[[simId]][[stateVariableParameterPath]],
+    0.045
+  )
+
+  # .evaluate() deposits a trial value: 50 ml is 0.05 l.
+  suppressMessages(priv$.evaluate(50))
+  expect_equal(
+    priv$.variableMolecules[[simId]][[stateVariableParameterPath]],
+    0.05
+  )
+
+  expect_false(
+    stateVariableParameterPath %in% names(priv$.variableParameters[[simId]])
+  )
+})
+
 test_that("objective function runs with only a state-variable parameter", {
   task <- testStateVariableOnlyTask()
   priv <- task$.__enclos_env__$private

--- a/tests/testthat/test-utilities-quantity.R
+++ b/tests/testthat/test-utilities-quantity.R
@@ -1,0 +1,28 @@
+# .toBaseValue
+
+clearancePiParameter <- function() {
+  clPath <- "Neighborhoods|Kidney_pls_Kidney_ur|Aciclovir|Renal Clearances-TS-Aciclovir|TSspec"
+  sim <- loadSimulation(
+    system.file("extdata", "Aciclovir.pkml", package = "ospsuite"),
+    loadFromCache = FALSE,
+    addToCache = FALSE
+  )
+  PIParameters$new(
+    parameters = list(getParameter(clPath, container = sim))
+  )
+}
+
+test_that(".toBaseValue converts a value from a non-base unit to the base unit", {
+  piParameter <- clearancePiParameter()
+  piParameter$unit <- ospUnits$`Inversed time`$`1/h`
+
+  # Independent oracle: 1/h to 1/min is a factor of 60 (T-6).
+  expect_equal(.toBaseValue(piParameter, 60), 60 / 60)
+})
+
+test_that(".toBaseValue passes a value through unchanged when unit is already base", {
+  piParameter <- clearancePiParameter()
+  expect_equal(piParameter$unit, ospUnits$`Inversed time`$`1/min`)
+
+  expect_equal(.toBaseValue(piParameter, 60), 60)
+})

--- a/tests/testthat/test-utilities-quantity.R
+++ b/tests/testthat/test-utilities-quantity.R
@@ -16,7 +16,6 @@ test_that(".toBaseValue converts a value from a non-base unit to the base unit",
   piParameter <- clearancePiParameter()
   piParameter$unit <- ospUnits$`Inversed time`$`1/h`
 
-  # Independent oracle: 1/h to 1/min is a factor of 60 (T-6).
   expect_equal(.toBaseValue(piParameter, 60), 60 / 60)
 })
 

--- a/vignettes/user-guide.Rmd
+++ b/vignettes/user-guide.Rmd
@@ -170,9 +170,9 @@ print(piParameterCl_250mg)
 print(piParameterCl_500mg)
 ```
 
-Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset to `1/min` above is required because changing `$unit` relabels the stored numbers without rescaling them: without it, the bounds and start value below would be interpreted as `1/h`, producing an interval that excludes the model's actual value.
+Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset to `1/min` above is required because changing `$unit` relabels the stored numbers without rescaling them: without it, the bounds and start value above would be interpreted as `1/h`, producing an interval that excludes the parameter's own current value of `0.94 1/min`.
 
-One caveat is algorithm-specific. `HJKB` probes with absolute step sizes in the declared unit, so the choice of `$unit` changes its search resolution. `BOBYQA` and `DEoptim`'s search is unaffected, because their step and population scales derive from the bounds. Hessian-based confidence intervals depend on the declared unit regardless of algorithm, because their finite-difference step is capped at an absolute value, whereas profile-likelihood and bootstrap intervals are scale-relative and unaffected.
+One caveat is algorithm-specific. `HJKB` probes with absolute step sizes in the declared unit, so the choice of `$unit` changes its search resolution. The search performed by `BOBYQA` and `DEoptim` is unaffected, because their step and population scales derive from the bounds. Hessian-based confidence intervals depend on the declared unit regardless of algorithm, because their finite-difference step is capped at an absolute value, whereas profile-likelihood and bootstrap intervals are scale-relative and unaffected.
 
 #### Mapping of model output to observed data
 

--- a/vignettes/user-guide.Rmd
+++ b/vignettes/user-guide.Rmd
@@ -161,7 +161,6 @@ piParameterCl_250mg$unit <- ospUnits$`Inversed time`$`1/min`
 piParameterCl_250mg$minValue <- 0
 piParameterCl_250mg$maxValue <- 10
 
-piParameterCl_500mg$unit <- ospUnits$`Inversed time`$`1/min`
 piParameterCl_500mg$minValue <- 0
 piParameterCl_500mg$maxValue <- 10
 
@@ -170,7 +169,7 @@ print(piParameterCl_250mg)
 print(piParameterCl_500mg)
 ```
 
-Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset of `piParameterCl_250mg$unit` to `1/min` above is required because changing `$unit` relabels the stored numbers without rescaling them: without it, its bounds and start value would be interpreted as `1/h`, producing an interval that excludes the parameter's own current value of `0.94 1/min`. `piParameterCl_500mg` was never switched to `1/h`, so its reset to `1/min` is a no-op shown only for symmetry with `piParameterCl_250mg`.
+Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset of `piParameterCl_250mg$unit` to `1/min` above is required because changing `$unit` relabels the stored numbers without rescaling them: without it, its bounds and start value would be interpreted as `1/h`, producing an interval that excludes the parameter's own current value of `0.94 1/min`.
 
 One caveat is algorithm-specific. `HJKB` probes with absolute step sizes in the declared unit, so the choice of `$unit` changes its search resolution. The search performed by `BOBYQA` and `DEoptim` is unaffected, because their step and population scales derive from the bounds.
 

--- a/vignettes/user-guide.Rmd
+++ b/vignettes/user-guide.Rmd
@@ -170,9 +170,9 @@ print(piParameterCl_250mg)
 print(piParameterCl_500mg)
 ```
 
-Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset to `1/min` above is required because changing `$unit` relabels the stored numbers without rescaling them: without it, the bounds and start value above would be interpreted as `1/h`, producing an interval that excludes the parameter's own current value of `0.94 1/min`.
+Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset of `piParameterCl_250mg$unit` to `1/min` above is required because changing `$unit` relabels the stored numbers without rescaling them: without it, its bounds and start value would be interpreted as `1/h`, producing an interval that excludes the parameter's own current value of `0.94 1/min`. `piParameterCl_500mg` was never switched to `1/h`, so its reset to `1/min` is a no-op shown only for symmetry with `piParameterCl_250mg`.
 
-One caveat is algorithm-specific. `HJKB` probes with absolute step sizes in the declared unit, so the choice of `$unit` changes its search resolution. The search performed by `BOBYQA` and `DEoptim` is unaffected, because their step and population scales derive from the bounds. Hessian-based confidence intervals depend on the declared unit regardless of algorithm, because their finite-difference step is capped at an absolute value, whereas profile-likelihood and bootstrap intervals are scale-relative and unaffected.
+One caveat is algorithm-specific. `HJKB` probes with absolute step sizes in the declared unit, so the choice of `$unit` changes its search resolution. The search performed by `BOBYQA` and `DEoptim` is unaffected, because their step and population scales derive from the bounds.
 
 #### Mapping of model output to observed data
 

--- a/vignettes/user-guide.Rmd
+++ b/vignettes/user-guide.Rmd
@@ -144,7 +144,7 @@ Each `PIParameter` has the following properties:
 print(piParameterCl_250mg)
 ```
 
-Setting the unit to `1/h` will cause the identification to start at `0.94 1/h`, the same stored number simply relabeled, while the current value is correctly converted from `0.94 1/min` to `0.94 1/min * 60 min/h = 56.47 1/h`:
+Setting the unit to `1/h` will cause the identification to start at `0.9412 1/h`, the same stored number simply relabeled, while the current value is correctly converted from `0.9412 1/min` to `0.9412 1/min * 60 min/h = 56.47 1/h`:
 
 ```{r}
 piParameterCl_250mg$unit <- ospUnits$`Inversed time`$`1/h`
@@ -169,7 +169,7 @@ print(piParameterCl_250mg)
 print(piParameterCl_500mg)
 ```
 
-Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset of `piParameterCl_250mg$unit` to `1/min` above is required because changing `$unit` relabels the stored numbers without rescaling them: without it, its bounds and start value would be interpreted as `1/h`, producing an interval that excludes the parameter's own current value of `0.94 1/min`.
+Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset of `piParameterCl_250mg$unit` to `1/min` above is required because changing `$unit` relabels the stored numbers without rescaling them: without it, its bounds and start value would be interpreted as `1/h`, producing an interval that excludes the parameter's own current value of `0.9412 1/min`.
 
 One caveat is algorithm-specific. `HJKB` probes with absolute step sizes in the declared unit, so the choice of `$unit` changes its search resolution. The search performed by `BOBYQA` and `DEoptim` is unaffected, because their step and population scales derive from the bounds.
 

--- a/vignettes/user-guide.Rmd
+++ b/vignettes/user-guide.Rmd
@@ -144,7 +144,7 @@ Each `PIParameter` has the following properties:
 print(piParameterCl_250mg)
 ```
 
-Setting the unit to `1/h` will cause the identification to start at `0.94 1/h`, while the current value is still `0.94 1/h` or `0.94 1/h * 60 min = 56.47 1/h`:
+Setting the unit to `1/h` will cause the identification to start at `0.94 1/h`, the same stored number simply relabeled, while the current value is correctly converted from `0.94 1/min` to `0.94 1/min * 60 min/h = 56.47 1/h`:
 
 ```{r}
 piParameterCl_250mg$unit <- ospUnits$`Inversed time`$`1/h`
@@ -170,9 +170,9 @@ print(piParameterCl_250mg)
 print(piParameterCl_500mg)
 ```
 
-Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset to `1/min` above precedes the bound assignments precisely because changing `$unit` relabels the stored numbers without rescaling them.
+Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset to `1/min` above is required because changing `$unit` relabels the stored numbers without rescaling them: without it, the bounds and start value below would be interpreted as `1/h`, producing an interval that excludes the model's actual value.
 
-One caveat is algorithm-specific. `HJKB` probes with absolute step sizes in the declared unit, so the choice of `$unit` changes its search resolution. `BOBYQA` and `DEoptim` are unaffected, because their step and population scales derive from the bounds.
+One caveat is algorithm-specific. `HJKB` probes with absolute step sizes in the declared unit, so the choice of `$unit` changes its search resolution. `BOBYQA` and `DEoptim`'s search is unaffected, because their step and population scales derive from the bounds. Hessian-based confidence intervals depend on the declared unit regardless of algorithm, because their finite-difference step is capped at an absolute value, whereas profile-likelihood and bootstrap intervals are scale-relative and unaffected.
 
 #### Mapping of model output to observed data
 

--- a/vignettes/user-guide.Rmd
+++ b/vignettes/user-guide.Rmd
@@ -157,19 +157,22 @@ We will set the boundaries for lipophilicity to [-10, 10], and for renal clearan
 piParameterLipo$minValue <- -10
 piParameterLipo$maxValue <- 10
 
+piParameterCl_250mg$unit <- ospUnits$`Inversed time`$`1/min`
 piParameterCl_250mg$minValue <- 0
 piParameterCl_250mg$maxValue <- 10
-piParameterCl_250mg$unit <- ospUnits$`Inversed time`$`1/min`
 
+piParameterCl_500mg$unit <- ospUnits$`Inversed time`$`1/min`
 piParameterCl_500mg$minValue <- 0
 piParameterCl_500mg$maxValue <- 10
-piParameterCl_500mg$unit <- ospUnits$`Inversed time`$`1/min`
 
 print(piParameterLipo)
 print(piParameterCl_250mg)
 print(piParameterCl_500mg)
 ```
 
+Values declared in `$unit` are converted to the parameter's base unit before they are applied to the model, so an identification can be set up in any unit of the parameter's dimension. The reset to `1/min` above precedes the bound assignments precisely because changing `$unit` relabels the stored numbers without rescaling them.
+
+One caveat is algorithm-specific. `HJKB` probes with absolute step sizes in the declared unit, so the choice of `$unit` changes its search resolution. `BOBYQA` and `DEoptim` are unaffected, because their step and population scales derive from the bounds.
 
 #### Mapping of model output to observed data
 


### PR DESCRIPTION
- Add `.toBaseValue()` and funnel every write into the simulation batches through one new `.applyParameterValues()` method, so a value converts from `$unit` to the parameter's base unit in a single place
- Cover the three paths that reach `addRunValues()` with regression tests, add a direct test for the conversion helper, and refresh three plot snapshots that were already stale on `main`
- Document the conversion on `PIParameters$unit`, on the `ParameterIdentification` constructor and on the methods that take a parameter vector, and correct the user guide passage that quietly relied on resetting `$unit` before running

Closes #298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parameter values and optimization bounds are now correctly converted from declared units before model evaluation.
  * Results remain consistent when equivalent values are expressed in different units.
  * Improved handling of state-variable and PK parameter units.
  * Added validation for mismatched parameter value counts.

* **Documentation**
  * Clarified unit interpretation, bounds, search resolution, and algorithm-specific behavior.
  * Updated user guidance with examples of unit conversion and validation.

* **Tests**
  * Added regression coverage across initialization, evaluation, PK runs, grid searches, plotting, and reported results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->